### PR TITLE
Fix panels not auto-refreshing on namespace/context switch

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -567,12 +567,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Update active panel
-	if len(m.panels) > m.activePanelIdx {
-		panel, cmd := m.panels[m.activePanelIdx].Update(msg)
-		m.panels[m.activePanelIdx] = panel
+	// Update ALL panels so they can process their respective loaded messages
+	// (e.g., podsLoadedMsg, deploymentsLoadedMsg) after namespace/context switch
+	for i := range m.panels {
+		panel, cmd := m.panels[i].Update(msg)
+		m.panels[i] = panel
 
-		cmds = append(cmds, cmd)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 
 	return m, tea.Batch(cmds...)


### PR DESCRIPTION
## Summary
- Fix bug where panels don't update when switching namespace or context
- Route messages to all panels instead of only the active panel
- Allows each panel to process its own loaded messages (e.g., podsLoadedMsg, deploymentsLoadedMsg)

## Test plan
- [x] Switch to a different namespace and verify all visible panels update their data
- [x] Switch to a different context and verify all visible panels refresh
- [x] Verify no regressions in normal panel navigation and interaction