### PR TITLE
Add deployment revision diff viewer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -123,6 +124,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
+github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
@@ -140,6 +143,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -199,12 +203,15 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSPG+6V4=
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -12,14 +12,12 @@ func TestClientSetNamespace(t *testing.T) {
 		namespace: "default",
 	}
 
-	// Test setting namespace
 	client.SetNamespace("my-namespace")
 
 	if client.namespace != "my-namespace" {
 		t.Errorf("SetNamespace() namespace = %q, want %q", client.namespace, "my-namespace")
 	}
 
-	// Test setting to empty string
 	client.SetNamespace("")
 
 	if client.namespace != "" {

--- a/internal/k8s/cronjobs_test.go
+++ b/internal/k8s/cronjobs_test.go
@@ -40,7 +40,6 @@ func TestListCronJobs(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing cronjobs in default namespace
 	cronjobs, err := client.ListCronJobs(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListCronJobs returned unexpected error: %v", err)
@@ -50,7 +49,6 @@ func TestListCronJobs(t *testing.T) {
 		t.Errorf("ListCronJobs returned %d cronjobs, want 2", len(cronjobs))
 	}
 
-	// Test listing cronjobs in other namespace
 	cronjobs, err = client.ListCronJobs(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListCronJobs returned unexpected error: %v", err)
@@ -60,7 +58,6 @@ func TestListCronJobs(t *testing.T) {
 		t.Errorf("ListCronJobs returned %d cronjobs, want 1", len(cronjobs))
 	}
 
-	// Test listing cronjobs with empty namespace (should use client's default)
 	cronjobs, err = client.ListCronJobs(ctx, "")
 	if err != nil {
 		t.Fatalf("ListCronJobs returned unexpected error: %v", err)
@@ -122,7 +119,6 @@ func TestGetCronJob(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing cronjob
 	cj, err := client.GetCronJob(ctx, "default", "test-cronjob")
 	if err != nil {
 		t.Fatalf("GetCronJob returned unexpected error: %v", err)
@@ -140,7 +136,6 @@ func TestGetCronJob(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent cronjob
 	_, err = client.GetCronJob(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetCronJob should have returned an error for non-existent cronjob")
@@ -160,13 +155,11 @@ func TestDeleteCronJob(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the cronjob
 	err := client.DeleteCronJob(ctx, "default", "test-cronjob")
 	if err != nil {
 		t.Fatalf("DeleteCronJob returned unexpected error: %v", err)
 	}
 
-	// Verify cronjob is deleted
 	_, err = client.GetCronJob(ctx, "default", "test-cronjob")
 	if err == nil {
 		t.Error("CronJob should have been deleted")
@@ -186,14 +179,12 @@ func TestWatchCronJobs(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchCronJobs(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchCronJobs returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchCronJobs returned watcher with nil ResultChan")
 	}
@@ -228,18 +219,15 @@ func TestTriggerCronJob(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Trigger the cronjob
 	job, err := client.TriggerCronJob(ctx, "default", "test-cronjob")
 	if err != nil {
 		t.Fatalf("TriggerCronJob returned unexpected error: %v", err)
 	}
 
-	// Verify job was created
 	if job == nil {
 		t.Fatal("TriggerCronJob should have returned a job")
 	}
 
-	// Verify job has the manual annotation
 	if job.Annotations["cronjob.kubernetes.io/instantiate"] != "manual" {
 		t.Error("Created job should have manual instantiate annotation")
 	}

--- a/internal/k8s/daemonsets_test.go
+++ b/internal/k8s/daemonsets_test.go
@@ -35,7 +35,6 @@ func TestListDaemonSets(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing daemonsets in default namespace
 	daemonsets, err := client.ListDaemonSets(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListDaemonSets returned unexpected error: %v", err)
@@ -45,7 +44,6 @@ func TestListDaemonSets(t *testing.T) {
 		t.Errorf("ListDaemonSets returned %d daemonsets, want 2", len(daemonsets))
 	}
 
-	// Test listing daemonsets in other namespace
 	daemonsets, err = client.ListDaemonSets(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListDaemonSets returned unexpected error: %v", err)
@@ -55,7 +53,6 @@ func TestListDaemonSets(t *testing.T) {
 		t.Errorf("ListDaemonSets returned %d daemonsets, want 1", len(daemonsets))
 	}
 
-	// Test listing daemonsets with empty namespace (should use client's default)
 	daemonsets, err = client.ListDaemonSets(ctx, "")
 	if err != nil {
 		t.Fatalf("ListDaemonSets returned unexpected error: %v", err)
@@ -121,7 +118,6 @@ func TestGetDaemonSet(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing daemonset
 	ds, err := client.GetDaemonSet(ctx, "default", "test-daemonset")
 	if err != nil {
 		t.Fatalf("GetDaemonSet returned unexpected error: %v", err)
@@ -138,7 +134,6 @@ func TestGetDaemonSet(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent daemonset
 	_, err = client.GetDaemonSet(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetDaemonSet should have returned an error for non-existent daemonset")
@@ -158,13 +153,11 @@ func TestDeleteDaemonSet(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the daemonset
 	err := client.DeleteDaemonSet(ctx, "default", "test-daemonset")
 	if err != nil {
 		t.Fatalf("DeleteDaemonSet returned unexpected error: %v", err)
 	}
 
-	// Verify daemonset is deleted
 	_, err = client.GetDaemonSet(ctx, "default", "test-daemonset")
 	if err == nil {
 		t.Error("DaemonSet should have been deleted")
@@ -184,14 +177,12 @@ func TestWatchDaemonSets(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchDaemonSets(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchDaemonSets returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchDaemonSets returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -514,6 +515,331 @@ func TestGetRevision(t *testing.T) {
 				t.Errorf("getRevision() = %d, want %d", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestGetOwnedReplicaSets(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	ownedRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "2",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+	}
+
+	ownedRS2 := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+	}
+
+	// Not owned by our deployment
+	unrelatedRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-rs",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "other-deployment"},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment, ownedRS, ownedRS2, unrelatedRS)
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	result, err := client.getOwnedReplicaSets(ctx, "default", "test-deployment")
+	if err != nil {
+		t.Fatalf("getOwnedReplicaSets returned unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("getOwnedReplicaSets returned %d RSs, want 2", len(result))
+	}
+
+	// Should be sorted descending by revision
+	if getRevision(&result[0]) != 2 {
+		t.Errorf("First RS revision = %d, want 2 (newest)", getRevision(&result[0]))
+	}
+
+	if getRevision(&result[1]) != 1 {
+		t.Errorf("Second RS revision = %d, want 1 (oldest)", getRevision(&result[1]))
+	}
+}
+
+func TestListDeploymentRevisions(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	rs1 := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:1.21"},
+					},
+				},
+			},
+		},
+	}
+
+	rs2 := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "2",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:1.20"},
+					},
+				},
+			},
+		},
+	}
+
+	rs3 := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs3",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:1.19"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment, rs1, rs2, rs3)
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	revisions, err := client.ListDeploymentRevisions(ctx, "default", "test-deployment")
+	if err != nil {
+		t.Fatalf("ListDeploymentRevisions returned unexpected error: %v", err)
+	}
+
+	if len(revisions) != 3 {
+		t.Fatalf("ListDeploymentRevisions returned %d revisions, want 3", len(revisions))
+	}
+
+	// Verify sorted descending
+	if revisions[0].Revision != 3 {
+		t.Errorf("First revision = %d, want 3", revisions[0].Revision)
+	}
+
+	if revisions[1].Revision != 2 {
+		t.Errorf("Second revision = %d, want 2", revisions[1].Revision)
+	}
+
+	if revisions[2].Revision != 1 {
+		t.Errorf("Third revision = %d, want 1", revisions[2].Revision)
+	}
+
+	// Verify template data
+	if len(revisions[0].Template.Spec.Containers) == 0 {
+		t.Fatal("Revision should have containers")
+	}
+
+	if revisions[0].Template.Spec.Containers[0].Image != "nginx:1.21" {
+		t.Errorf(
+			"Newest revision image = %q, want %q",
+			revisions[0].Template.Spec.Containers[0].Image,
+			"nginx:1.21",
+		)
+	}
+}
+
+func TestListDeploymentRevisionsEmpty(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	revisions, err := client.ListDeploymentRevisions(ctx, "default", "test-deployment")
+	if err != nil {
+		t.Fatalf("ListDeploymentRevisions returned unexpected error: %v", err)
+	}
+
+	if len(revisions) != 0 {
+		t.Errorf("ListDeploymentRevisions returned %d revisions, want 0", len(revisions))
+	}
+}
+
+func TestGetRevisionYAML(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx:1.19"},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment, rs)
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	yamlStr, err := client.GetRevisionYAML(ctx, "default", "test-deployment", 1)
+	if err != nil {
+		t.Fatalf("GetRevisionYAML returned unexpected error: %v", err)
+	}
+
+	if yamlStr == "" {
+		t.Error("GetRevisionYAML should return non-empty YAML")
+	}
+
+	if !strings.Contains(yamlStr, "nginx:1.19") {
+		t.Errorf("YAML should contain image name, got:\n%s", yamlStr)
+	}
+}
+
+func TestGetRevisionYAMLNotFound(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment-rs1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+			Labels: map[string]string{"app": "test"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "test-deployment"},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment, rs)
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	_, err := client.GetRevisionYAML(ctx, "default", "test-deployment", 99)
+	if err == nil {
+		t.Error("GetRevisionYAML should return error for non-existent revision")
+	}
+
+	if !errors.Is(err, ErrRevisionNotFound) {
+		t.Errorf("GetRevisionYAML error = %v, want ErrRevisionNotFound", err)
 	}
 }
 

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -41,7 +41,6 @@ func TestListDeployments(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing deployments in default namespace
 	deployments, err := client.ListDeployments(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListDeployments returned unexpected error: %v", err)
@@ -51,7 +50,6 @@ func TestListDeployments(t *testing.T) {
 		t.Errorf("ListDeployments returned %d deployments, want 2", len(deployments))
 	}
 
-	// Test listing deployments in other namespace
 	deployments, err = client.ListDeployments(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListDeployments returned unexpected error: %v", err)
@@ -61,7 +59,6 @@ func TestListDeployments(t *testing.T) {
 		t.Errorf("ListDeployments returned %d deployments, want 1", len(deployments))
 	}
 
-	// Test listing deployments with empty namespace (should use client's default)
 	deployments, err = client.ListDeployments(ctx, "")
 	if err != nil {
 		t.Fatalf("ListDeployments returned unexpected error: %v", err)
@@ -126,7 +123,6 @@ func TestGetDeployment(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing deployment
 	deployment, err := client.GetDeployment(ctx, "default", "test-deployment")
 	if err != nil {
 		t.Fatalf("GetDeployment returned unexpected error: %v", err)
@@ -147,7 +143,6 @@ func TestGetDeployment(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent deployment
 	_, err = client.GetDeployment(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetDeployment should have returned an error for non-existent deployment")
@@ -167,13 +162,11 @@ func TestDeleteDeployment(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the deployment
 	err := client.DeleteDeployment(ctx, "default", "test-deployment")
 	if err != nil {
 		t.Fatalf("DeleteDeployment returned unexpected error: %v", err)
 	}
 
-	// Verify deployment is deleted
 	_, err = client.GetDeployment(ctx, "default", "test-deployment")
 	if err == nil {
 		t.Error("Deployment should have been deleted")
@@ -200,13 +193,11 @@ func TestUpdateDeployment(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Get the deployment
 	deployment, err := client.GetDeployment(ctx, "default", "test-deployment")
 	if err != nil {
 		t.Fatalf("GetDeployment returned unexpected error: %v", err)
 	}
 
-	// Update the deployment
 	deployment.Spec.Replicas = int32Ptr(10)
 	deployment.Labels = map[string]string{"updated": "true"}
 
@@ -237,14 +228,12 @@ func TestWatchDeployments(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchDeployments(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchDeployments returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchDeployments returned watcher with nil ResultChan")
 	}
@@ -387,7 +376,6 @@ func TestRollbackDeployment(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Execute rollback
 	err := client.RollbackDeployment(ctx, "default", "test-deployment")
 	if err != nil {
 		t.Fatalf("RollbackDeployment returned unexpected error: %v", err)

--- a/internal/k8s/hpa_test.go
+++ b/internal/k8s/hpa_test.go
@@ -34,7 +34,6 @@ func TestListHPAs(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing HPAs in default namespace
 	hpas, err := client.ListHPAs(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListHPAs returned unexpected error: %v", err)
@@ -44,7 +43,6 @@ func TestListHPAs(t *testing.T) {
 		t.Errorf("ListHPAs returned %d HPAs, want 2", len(hpas))
 	}
 
-	// Test listing HPAs in other namespace
 	hpas, err = client.ListHPAs(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListHPAs returned unexpected error: %v", err)
@@ -54,7 +52,6 @@ func TestListHPAs(t *testing.T) {
 		t.Errorf("ListHPAs returned %d HPAs, want 1", len(hpas))
 	}
 
-	// Test listing HPAs with empty namespace (should use client's default)
 	hpas, err = client.ListHPAs(ctx, "")
 	if err != nil {
 		t.Fatalf("ListHPAs returned unexpected error: %v", err)
@@ -117,7 +114,6 @@ func TestGetHPA(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing HPA
 	hpa, err := client.GetHPA(ctx, "default", "test-hpa")
 	if err != nil {
 		t.Fatalf("GetHPA returned unexpected error: %v", err)
@@ -131,7 +127,6 @@ func TestGetHPA(t *testing.T) {
 		t.Errorf("GetHPA returned HPA with max replicas %d, want 10", hpa.Spec.MaxReplicas)
 	}
 
-	// Test getting non-existent HPA
 	_, err = client.GetHPA(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetHPA should have returned an error for non-existent HPA")
@@ -151,13 +146,11 @@ func TestDeleteHPA(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the HPA
 	err := client.DeleteHPA(ctx, "default", "test-hpa")
 	if err != nil {
 		t.Fatalf("DeleteHPA returned unexpected error: %v", err)
 	}
 
-	// Verify HPA is deleted
 	_, err = client.GetHPA(ctx, "default", "test-hpa")
 	if err == nil {
 		t.Error("HPA should have been deleted")
@@ -177,14 +170,12 @@ func TestWatchHPAs(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchHPAs(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchHPAs returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchHPAs returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/namespaces_test.go
+++ b/internal/k8s/namespaces_test.go
@@ -49,7 +49,6 @@ func TestListNamespaces(t *testing.T) {
 		t.Errorf("ListNamespaces returned %d namespaces, want 3", len(namespaces))
 	}
 
-	// Verify expected namespaces are present
 	foundNames := make(map[string]bool)
 	for _, ns := range namespaces {
 		foundNames[ns.Name] = true
@@ -80,7 +79,6 @@ func TestGetNamespace(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing namespace
 	ns, err := client.GetNamespace(ctx, "default")
 	if err != nil {
 		t.Fatalf("GetNamespace returned unexpected error: %v", err)
@@ -94,7 +92,6 @@ func TestGetNamespace(t *testing.T) {
 		t.Errorf("GetNamespace returned namespace with wrong label")
 	}
 
-	// Test getting non-existent namespace
 	_, err = client.GetNamespace(ctx, "non-existent")
 	if err == nil {
 		t.Error("GetNamespace should have returned an error for non-existent namespace")
@@ -107,7 +104,6 @@ func TestCreateNamespace(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Create a new namespace
 	ns, err := client.CreateNamespace(ctx, "new-namespace")
 	if err != nil {
 		t.Fatalf("CreateNamespace returned unexpected error: %v", err)
@@ -121,7 +117,6 @@ func TestCreateNamespace(t *testing.T) {
 		)
 	}
 
-	// Verify namespace was created
 	created, err := client.GetNamespace(ctx, "new-namespace")
 	if err != nil {
 		t.Fatalf("GetNamespace returned unexpected error: %v", err)
@@ -144,19 +139,16 @@ func TestDeleteNamespace(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Verify namespace exists
 	_, err := client.GetNamespace(ctx, "to-delete")
 	if err != nil {
 		t.Fatalf("GetNamespace returned unexpected error: %v", err)
 	}
 
-	// Delete the namespace
 	err = client.DeleteNamespace(ctx, "to-delete")
 	if err != nil {
 		t.Fatalf("DeleteNamespace returned unexpected error: %v", err)
 	}
 
-	// Verify namespace is deleted
 	_, err = client.GetNamespace(ctx, "to-delete")
 	if err == nil {
 		t.Error("Namespace should have been deleted")
@@ -175,14 +167,12 @@ func TestWatchNamespaces(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchNamespaces(ctx)
 	if err != nil {
 		t.Fatalf("WatchNamespaces returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchNamespaces returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/networkpolicies_test.go
+++ b/internal/k8s/networkpolicies_test.go
@@ -35,7 +35,6 @@ func TestListNetworkPolicies(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing network policies in default namespace
 	netpols, err := client.ListNetworkPolicies(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListNetworkPolicies returned unexpected error: %v", err)
@@ -45,7 +44,6 @@ func TestListNetworkPolicies(t *testing.T) {
 		t.Errorf("ListNetworkPolicies returned %d network policies, want 2", len(netpols))
 	}
 
-	// Test listing network policies in other namespace
 	netpols, err = client.ListNetworkPolicies(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListNetworkPolicies returned unexpected error: %v", err)
@@ -55,7 +53,6 @@ func TestListNetworkPolicies(t *testing.T) {
 		t.Errorf("ListNetworkPolicies returned %d network policies, want 1", len(netpols))
 	}
 
-	// Test listing network policies with empty namespace
 	netpols, err = client.ListNetworkPolicies(ctx, "")
 	if err != nil {
 		t.Fatalf("ListNetworkPolicies returned unexpected error: %v", err)
@@ -125,7 +122,6 @@ func TestGetNetworkPolicy(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing network policy
 	np, err := client.GetNetworkPolicy(ctx, "default", "test-netpol")
 	if err != nil {
 		t.Fatalf("GetNetworkPolicy returned unexpected error: %v", err)
@@ -139,7 +135,6 @@ func TestGetNetworkPolicy(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent network policy
 	_, err = client.GetNetworkPolicy(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetNetworkPolicy should have returned an error for non-existent network policy")
@@ -159,13 +154,11 @@ func TestDeleteNetworkPolicy(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the network policy
 	err := client.DeleteNetworkPolicy(ctx, "default", "test-netpol")
 	if err != nil {
 		t.Fatalf("DeleteNetworkPolicy returned unexpected error: %v", err)
 	}
 
-	// Verify network policy is deleted
 	_, err = client.GetNetworkPolicy(ctx, "default", "test-netpol")
 	if err == nil {
 		t.Error("NetworkPolicy should have been deleted")
@@ -185,14 +178,12 @@ func TestWatchNetworkPolicies(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchNetworkPolicies(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchNetworkPolicies returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchNetworkPolicies returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/pods_test.go
+++ b/internal/k8s/pods_test.go
@@ -16,8 +16,6 @@ func createTestClient(clientset *fake.Clientset) *Client {
 	}
 }
 
-// Note: The Client struct uses kubernetes.Interface which allows using fake.Clientset for testing
-
 func TestListPods(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&corev1.Pod{
@@ -49,7 +47,6 @@ func TestListPods(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing pods in default namespace
 	pods, err := client.ListPods(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListPods returned unexpected error: %v", err)
@@ -59,7 +56,6 @@ func TestListPods(t *testing.T) {
 		t.Errorf("ListPods returned %d pods, want 2", len(pods))
 	}
 
-	// Test listing pods in other namespace
 	pods, err = client.ListPods(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListPods returned unexpected error: %v", err)
@@ -69,7 +65,6 @@ func TestListPods(t *testing.T) {
 		t.Errorf("ListPods returned %d pods, want 1", len(pods))
 	}
 
-	// Test listing pods with empty namespace (should use client's default)
 	pods, err = client.ListPods(ctx, "")
 	if err != nil {
 		t.Fatalf("ListPods returned unexpected error: %v", err)
@@ -133,7 +128,6 @@ func TestGetPod(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing pod
 	pod, err := client.GetPod(ctx, "default", "test-pod")
 	if err != nil {
 		t.Fatalf("GetPod returned unexpected error: %v", err)
@@ -147,13 +141,11 @@ func TestGetPod(t *testing.T) {
 		t.Errorf("GetPod returned pod with %d containers, want 1", len(pod.Spec.Containers))
 	}
 
-	// Test getting non-existent pod
 	_, err = client.GetPod(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetPod should have returned an error for non-existent pod")
 	}
 
-	// Test getting pod with empty namespace (should use client's default)
 	pod, err = client.GetPod(ctx, "", "test-pod")
 	if err != nil {
 		t.Fatalf("GetPod with empty namespace returned unexpected error: %v", err)
@@ -177,13 +169,11 @@ func TestDeletePod(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the pod
 	err := client.DeletePod(ctx, "default", "test-pod")
 	if err != nil {
 		t.Fatalf("DeletePod returned unexpected error: %v", err)
 	}
 
-	// Verify pod is deleted
 	_, err = client.GetPod(ctx, "default", "test-pod")
 	if err == nil {
 		t.Error("Pod should have been deleted")
@@ -468,14 +458,12 @@ func TestWatchPods(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchPods(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchPods returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchPods returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/portforward_test.go
+++ b/internal/k8s/portforward_test.go
@@ -70,13 +70,10 @@ func TestPortForwarderStop(t *testing.T) {
 		t.Fatalf("NewPortForwarder returned unexpected error: %v", err)
 	}
 
-	// Stop should close the channel
 	pf.Stop()
 
-	// Verify channel is closed
 	select {
 	case <-stopCh:
-		// Channel is closed as expected
 	default:
 		t.Error("Stop() should close the StopCh")
 	}

--- a/internal/k8s/serviceaccounts_test.go
+++ b/internal/k8s/serviceaccounts_test.go
@@ -34,7 +34,6 @@ func TestListServiceAccounts(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing service accounts in default namespace
 	sas, err := client.ListServiceAccounts(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListServiceAccounts returned unexpected error: %v", err)
@@ -44,7 +43,6 @@ func TestListServiceAccounts(t *testing.T) {
 		t.Errorf("ListServiceAccounts returned %d service accounts, want 2", len(sas))
 	}
 
-	// Test listing service accounts in other namespace
 	sas, err = client.ListServiceAccounts(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListServiceAccounts returned unexpected error: %v", err)
@@ -54,7 +52,6 @@ func TestListServiceAccounts(t *testing.T) {
 		t.Errorf("ListServiceAccounts returned %d service accounts, want 1", len(sas))
 	}
 
-	// Test listing service accounts with empty namespace
 	sas, err = client.ListServiceAccounts(ctx, "")
 	if err != nil {
 		t.Fatalf("ListServiceAccounts returned unexpected error: %v", err)
@@ -119,7 +116,6 @@ func TestGetServiceAccount(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing service account
 	sa, err := client.GetServiceAccount(ctx, "default", "test-sa")
 	if err != nil {
 		t.Fatalf("GetServiceAccount returned unexpected error: %v", err)
@@ -140,7 +136,6 @@ func TestGetServiceAccount(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent service account
 	_, err = client.GetServiceAccount(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetServiceAccount should have returned an error for non-existent service account")
@@ -160,13 +155,11 @@ func TestDeleteServiceAccount(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the service account
 	err := client.DeleteServiceAccount(ctx, "default", "test-sa")
 	if err != nil {
 		t.Fatalf("DeleteServiceAccount returned unexpected error: %v", err)
 	}
 
-	// Verify service account is deleted
 	_, err = client.GetServiceAccount(ctx, "default", "test-sa")
 	if err == nil {
 		t.Error("ServiceAccount should have been deleted")
@@ -186,14 +179,12 @@ func TestWatchServiceAccounts(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchServiceAccounts(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchServiceAccounts returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchServiceAccounts returned watcher with nil ResultChan")
 	}

--- a/internal/k8s/statefulsets_test.go
+++ b/internal/k8s/statefulsets_test.go
@@ -35,7 +35,6 @@ func TestListStatefulSets(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test listing statefulsets in default namespace
 	statefulsets, err := client.ListStatefulSets(ctx, "default")
 	if err != nil {
 		t.Fatalf("ListStatefulSets returned unexpected error: %v", err)
@@ -45,7 +44,6 @@ func TestListStatefulSets(t *testing.T) {
 		t.Errorf("ListStatefulSets returned %d statefulsets, want 2", len(statefulsets))
 	}
 
-	// Test listing statefulsets in other namespace
 	statefulsets, err = client.ListStatefulSets(ctx, "other-namespace")
 	if err != nil {
 		t.Fatalf("ListStatefulSets returned unexpected error: %v", err)
@@ -55,7 +53,6 @@ func TestListStatefulSets(t *testing.T) {
 		t.Errorf("ListStatefulSets returned %d statefulsets, want 1", len(statefulsets))
 	}
 
-	// Test listing statefulsets with empty namespace (should use client's default)
 	statefulsets, err = client.ListStatefulSets(ctx, "")
 	if err != nil {
 		t.Fatalf("ListStatefulSets returned unexpected error: %v", err)
@@ -123,7 +120,6 @@ func TestGetStatefulSet(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test getting existing statefulset
 	sts, err := client.GetStatefulSet(ctx, "default", "test-statefulset")
 	if err != nil {
 		t.Fatalf("GetStatefulSet returned unexpected error: %v", err)
@@ -144,7 +140,6 @@ func TestGetStatefulSet(t *testing.T) {
 		)
 	}
 
-	// Test getting non-existent statefulset
 	_, err = client.GetStatefulSet(ctx, "default", "non-existent")
 	if err == nil {
 		t.Error("GetStatefulSet should have returned an error for non-existent statefulset")
@@ -164,13 +159,11 @@ func TestDeleteStatefulSet(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Delete the statefulset
 	err := client.DeleteStatefulSet(ctx, "default", "test-statefulset")
 	if err != nil {
 		t.Fatalf("DeleteStatefulSet returned unexpected error: %v", err)
 	}
 
-	// Verify statefulset is deleted
 	_, err = client.GetStatefulSet(ctx, "default", "test-statefulset")
 	if err == nil {
 		t.Error("StatefulSet should have been deleted")
@@ -190,14 +183,12 @@ func TestWatchStatefulSets(t *testing.T) {
 	client := createTestClient(clientset)
 	ctx := context.Background()
 
-	// Test creating a watch
 	watcher, err := client.WatchStatefulSets(ctx, "default")
 	if err != nil {
 		t.Fatalf("WatchStatefulSets returned unexpected error: %v", err)
 	}
 	defer watcher.Stop()
 
-	// Verify watch channel is available
 	if watcher.ResultChan() == nil {
 		t.Error("WatchStatefulSets returned watcher with nil ResultChan")
 	}

--- a/internal/ui/components/diff_viewer.go
+++ b/internal/ui/components/diff_viewer.go
@@ -1,0 +1,391 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"github.com/Starlexxx/lazy-k8s/internal/ui/theme"
+)
+
+// DiffLineType categorizes a line in a unified diff view.
+type DiffLineType int
+
+const (
+	DiffLineContext DiffLineType = iota
+	DiffLineAdded
+	DiffLineRemoved
+	DiffLineHeader
+)
+
+// DiffLine represents a single line in the diff output.
+type DiffLine struct {
+	Text string
+	Type DiffLineType
+}
+
+// DiffViewer displays a unified diff between two YAML strings
+// with colored additions/removals and search support.
+type DiffViewer struct {
+	styles       *theme.Styles
+	title        string
+	lines        []DiffLine
+	offset       int
+	width        int
+	height       int
+	searchActive bool
+	searchInput  textinput.Model
+	searchQuery  string
+	matchLines   []int
+	matchIndex   int
+}
+
+// NewDiffViewer creates a DiffViewer with search text input pre-configured.
+func NewDiffViewer(styles *theme.Styles) *DiffViewer {
+	ti := textinput.New()
+	ti.Placeholder = "search..."
+	ti.CharLimit = 100
+	ti.Width = 30
+	ti.Prompt = "/ "
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(styles.Primary)
+	ti.TextStyle = lipgloss.NewStyle().Foreground(styles.Text)
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(styles.MutedColor)
+
+	return &DiffViewer{
+		styles:      styles,
+		searchInput: ti,
+		matchLines:  make([]int, 0),
+	}
+}
+
+// SetContent computes a line-level diff between oldYAML and newYAML
+// and stores the result for rendering.
+func (d *DiffViewer) SetContent(title, oldYAML, newYAML string) {
+	d.title = title
+	d.offset = 0
+	d.searchQuery = ""
+	d.matchLines = make([]int, 0)
+	d.matchIndex = 0
+
+	d.lines = computeDiff(oldYAML, newYAML)
+}
+
+// computeDiff produces line-level diff output using character-based diffing
+// mapped back to lines via DiffLinesToChars / DiffCharsToLines.
+func computeDiff(oldText, newText string) []DiffLine {
+	dmp := diffmatchpatch.New()
+
+	// Convert line-level changes to character representation,
+	// diff at character level, then map back to lines for readable output.
+	charA, charB, lineArray := dmp.DiffLinesToChars(oldText, newText)
+	diffs := dmp.DiffMain(charA, charB, false)
+	diffs = dmp.DiffCharsToLines(diffs, lineArray)
+
+	var result []DiffLine
+
+	for _, d := range diffs {
+		lines := strings.Split(strings.TrimRight(d.Text, "\n"), "\n")
+
+		for _, line := range lines {
+			switch d.Type {
+			case diffmatchpatch.DiffEqual:
+				result = append(result, DiffLine{
+					Text: line,
+					Type: DiffLineContext,
+				})
+			case diffmatchpatch.DiffInsert:
+				result = append(result, DiffLine{
+					Text: line,
+					Type: DiffLineAdded,
+				})
+			case diffmatchpatch.DiffDelete:
+				result = append(result, DiffLine{
+					Text: line,
+					Type: DiffLineRemoved,
+				})
+			}
+		}
+	}
+
+	return result
+}
+
+func (d *DiffViewer) Update(msg tea.Msg) (*DiffViewer, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if d.searchActive {
+			return d.handleSearchKey(msg)
+		}
+
+		return d.handleNormalKey(msg)
+	}
+
+	return d, nil
+}
+
+func (d *DiffViewer) handleSearchKey(msg tea.KeyMsg) (*DiffViewer, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		d.searchActive = false
+		d.searchInput.Blur()
+
+		return d, nil
+	case "enter":
+		d.searchActive = false
+		d.searchInput.Blur()
+		d.performSearch()
+
+		if len(d.matchLines) > 0 {
+			d.matchIndex = 0
+			d.offset = d.matchLines[0]
+		}
+
+		return d, nil
+	default:
+		var cmd tea.Cmd
+
+		d.searchInput, cmd = d.searchInput.Update(msg)
+		d.searchQuery = d.searchInput.Value()
+
+		return d, cmd
+	}
+}
+
+func (d *DiffViewer) handleNormalKey(msg tea.KeyMsg) (*DiffViewer, tea.Cmd) {
+	switch msg.String() {
+	case "/":
+		d.searchActive = true
+		d.searchInput.Focus()
+		d.searchInput.SetValue("")
+
+		return d, nil
+	case "n":
+		if len(d.matchLines) > 0 {
+			d.matchIndex = (d.matchIndex + 1) % len(d.matchLines)
+			d.offset = d.matchLines[d.matchIndex]
+		}
+	case "N":
+		if len(d.matchLines) > 0 {
+			d.matchIndex--
+			if d.matchIndex < 0 {
+				d.matchIndex = len(d.matchLines) - 1
+			}
+
+			d.offset = d.matchLines[d.matchIndex]
+		}
+	case "up", "k":
+		if d.offset > 0 {
+			d.offset--
+		}
+	case "down", "j":
+		if d.offset < d.maxOffset() {
+			d.offset++
+		}
+	case "g":
+		d.offset = 0
+	case "G":
+		d.offset = d.maxOffset()
+	case "pgup", "ctrl+u":
+		d.offset -= d.height / 2
+		if d.offset < 0 {
+			d.offset = 0
+		}
+	case "pgdown", "ctrl+d":
+		d.offset += d.height / 2
+		if d.offset > d.maxOffset() {
+			d.offset = d.maxOffset()
+		}
+	}
+
+	return d, nil
+}
+
+func (d *DiffViewer) maxOffset() int {
+	offset := len(d.lines) - d.visibleHeight() + 1
+	if offset < 0 {
+		return 0
+	}
+
+	return offset
+}
+
+func (d *DiffViewer) visibleHeight() int {
+	h := d.height - 7
+	if d.searchActive || (d.searchQuery != "" && len(d.matchLines) > 0) {
+		h--
+	}
+
+	if h < 1 {
+		h = 1
+	}
+
+	return h
+}
+
+func (d *DiffViewer) performSearch() {
+	d.matchLines = make([]int, 0)
+
+	if d.searchQuery == "" {
+		return
+	}
+
+	query := strings.ToLower(d.searchQuery)
+
+	for i, line := range d.lines {
+		if strings.Contains(strings.ToLower(line.Text), query) {
+			d.matchLines = append(d.matchLines, i)
+		}
+	}
+}
+
+func (d *DiffViewer) View(width, height int) string {
+	d.width = width
+	d.height = height
+
+	var b strings.Builder
+
+	title := d.styles.ModalTitle.Render(d.title)
+
+	var hint string
+	if d.searchActive {
+		hint = d.styles.Muted.Render("enter search • esc cancel")
+	} else {
+		hint = d.styles.Muted.Render(
+			"/ search • n/N next/prev • ↑/↓ scroll • esc close",
+		)
+	}
+
+	titleBar := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", hint)
+	b.WriteString(titleBar)
+	b.WriteString("\n")
+
+	if d.searchActive {
+		d.searchInput.Width = width - 10
+		b.WriteString(d.searchInput.View())
+		b.WriteString("\n")
+	} else if d.searchQuery != "" && len(d.matchLines) > 0 {
+		matchInfo := lipgloss.NewStyle().Foreground(d.styles.Primary).Render(
+			fmt.Sprintf(
+				" [%s] %d/%d matches",
+				d.searchQuery,
+				d.matchIndex+1,
+				len(d.matchLines),
+			),
+		)
+		b.WriteString(matchInfo)
+		b.WriteString("\n")
+	}
+
+	b.WriteString(strings.Repeat("─", width-4))
+	b.WriteString("\n")
+
+	visibleHeight := d.visibleHeight()
+
+	endIdx := d.offset + visibleHeight
+	if endIdx > len(d.lines) {
+		endIdx = len(d.lines)
+	}
+
+	maxLineWidth := width - 8
+
+	for i := d.offset; i < endIdx; i++ {
+		line := d.lines[i]
+		rendered := d.renderDiffLine(line, maxLineWidth, i)
+		b.WriteString(rendered)
+		b.WriteString("\n")
+	}
+
+	d.renderScrollbar(&b, visibleHeight, width)
+
+	return d.styles.Modal.
+		Width(width - 4).
+		Height(height - 2).
+		Render(b.String())
+}
+
+func (d *DiffViewer) renderDiffLine(line DiffLine, maxWidth, lineIdx int) string {
+	text := line.Text
+	if len(text) > maxWidth {
+		text = text[:maxWidth-3] + "..."
+	}
+
+	var prefix string
+
+	var style lipgloss.Style
+
+	switch line.Type {
+	case DiffLineAdded:
+		prefix = "+ "
+		style = d.styles.DiffAdded
+	case DiffLineRemoved:
+		prefix = "- "
+		style = d.styles.DiffRemoved
+	case DiffLineHeader:
+		prefix = "  "
+		style = d.styles.DetailTitle
+	case DiffLineContext:
+		prefix = "  "
+		style = lipgloss.NewStyle().Foreground(d.styles.Text)
+	}
+
+	rendered := style.Render(prefix + text)
+
+	// Highlight search matches
+	if d.searchQuery != "" &&
+		strings.Contains(strings.ToLower(line.Text), strings.ToLower(d.searchQuery)) {
+		if d.isCurrentMatch(lineIdx) {
+			rendered = d.styles.ListItemFocused.Render("► " + prefix + text)
+		} else {
+			rendered = lipgloss.NewStyle().
+				Background(lipgloss.Color("#3d4966")).
+				Render(prefix + text)
+		}
+	}
+
+	return rendered
+}
+
+func (d *DiffViewer) renderScrollbar(b *strings.Builder, visibleHeight, width int) {
+	if len(d.lines) <= visibleHeight || width <= 12 {
+		return
+	}
+
+	scrollPos := float64(d.offset) / float64(len(d.lines)-visibleHeight)
+	barWidth := width - 10
+
+	leftWidth := int(float64(barWidth) * scrollPos)
+	if leftWidth < 0 {
+		leftWidth = 0
+	}
+
+	if leftWidth > barWidth {
+		leftWidth = barWidth
+	}
+
+	rightWidth := barWidth - leftWidth - 1
+	if rightWidth < 0 {
+		rightWidth = 0
+	}
+
+	indicator := strings.Repeat("─", leftWidth) + "█" + strings.Repeat("─", rightWidth)
+
+	b.WriteString("\n")
+	b.WriteString(d.styles.Muted.Render(indicator))
+}
+
+func (d *DiffViewer) isCurrentMatch(lineIdx int) bool {
+	if len(d.matchLines) == 0 || d.matchIndex >= len(d.matchLines) {
+		return false
+	}
+
+	return d.matchLines[d.matchIndex] == lineIdx
+}
+
+// Lines returns the computed diff lines (used in tests).
+func (d *DiffViewer) Lines() []DiffLine {
+	return d.lines
+}

--- a/internal/ui/components/diff_viewer_test.go
+++ b/internal/ui/components/diff_viewer_test.go
@@ -1,0 +1,415 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNewDiffViewer(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	if viewer == nil {
+		t.Fatal("NewDiffViewer returned nil")
+	}
+
+	if len(viewer.Lines()) != 0 {
+		t.Error("New viewer should have no lines")
+	}
+}
+
+func TestDiffViewerSetContent(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Test Diff", "line1\nline2\n", "line1\nline3\n")
+
+	if len(viewer.Lines()) == 0 {
+		t.Error("SetContent should produce diff lines")
+	}
+}
+
+func TestDiffViewerIdenticalContent(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	content := "apiVersion: v1\nkind: Pod\n"
+	viewer.SetContent("No changes", content, content)
+
+	for _, line := range viewer.Lines() {
+		if line.Type != DiffLineContext {
+			t.Errorf(
+				"Identical content should produce only context lines, got type %d for %q",
+				line.Type, line.Text,
+			)
+		}
+	}
+}
+
+func TestDiffViewerAddedLines(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Added", "line1\n", "line1\nline2\n")
+
+	hasAdded := false
+
+	for _, line := range viewer.Lines() {
+		if line.Type == DiffLineAdded {
+			hasAdded = true
+
+			break
+		}
+	}
+
+	if !hasAdded {
+		t.Error("Diff should contain added lines")
+	}
+}
+
+func TestDiffViewerRemovedLines(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Removed", "line1\nline2\n", "line1\n")
+
+	hasRemoved := false
+
+	for _, line := range viewer.Lines() {
+		if line.Type == DiffLineRemoved {
+			hasRemoved = true
+
+			break
+		}
+	}
+
+	if !hasRemoved {
+		t.Error("Diff should contain removed lines")
+	}
+}
+
+func TestDiffViewerView(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Test Diff", "old\n", "new\n")
+
+	view := viewer.View(80, 24)
+
+	if view == "" {
+		t.Error("View should not be empty")
+	}
+
+	if !strings.Contains(view, "Test Diff") {
+		t.Error("View should contain title")
+	}
+}
+
+func TestDiffViewerScrollDown(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Scroll", old, old)
+
+	msg := tea.KeyMsg{Type: tea.KeyDown}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset != 1 {
+		t.Errorf("offset = %d, want 1", viewer.offset)
+	}
+}
+
+func TestDiffViewerScrollUp(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Scroll", old, old)
+	viewer.offset = 5
+
+	msg := tea.KeyMsg{Type: tea.KeyUp}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset != 4 {
+		t.Errorf("offset = %d, want 4", viewer.offset)
+	}
+}
+
+func TestDiffViewerScrollUpAtTop(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Top", "a\nb\n", "a\nb\n")
+	viewer.offset = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyUp}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset != 0 {
+		t.Errorf("offset = %d, want 0 (should not go negative)", viewer.offset)
+	}
+}
+
+func TestDiffViewerJumpToTop(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Jump", old, old)
+	viewer.offset = 50
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset != 0 {
+		t.Errorf("offset = %d, want 0", viewer.offset)
+	}
+}
+
+func TestDiffViewerJumpToBottom(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Jump", old, old)
+	viewer.height = 20
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset == 0 {
+		t.Error("offset should not be 0 after jumping to bottom")
+	}
+}
+
+func TestDiffViewerSearchActivation(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Search", "line1\n", "line1\n")
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}
+	viewer, _ = viewer.Update(msg)
+
+	if !viewer.searchActive {
+		t.Error("Search should be active after pressing /")
+	}
+}
+
+func TestDiffViewerSearchEscape(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Search", "a\n", "a\n")
+	viewer.searchActive = true
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.searchActive {
+		t.Error("Search should be inactive after pressing Escape")
+	}
+}
+
+func TestDiffViewerSearchEnter(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Search", "hello\nworld\n", "hello\nworld\n")
+	viewer.searchActive = true
+	viewer.searchQuery = "world"
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.searchActive {
+		t.Error("Search should be inactive after pressing Enter")
+	}
+
+	if len(viewer.matchLines) == 0 {
+		t.Error("Should have found matches")
+	}
+}
+
+func TestDiffViewerSearchNextMatch(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Match", "foo\nbar\nfoo\n", "foo\nbar\nfoo\n")
+	viewer.searchQuery = "foo"
+	viewer.performSearch()
+	viewer.matchIndex = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.matchIndex != 1 {
+		t.Errorf("matchIndex = %d, want 1", viewer.matchIndex)
+	}
+}
+
+func TestDiffViewerSearchPrevMatch(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Match", "foo\nbar\nfoo\n", "foo\nbar\nfoo\n")
+	viewer.searchQuery = "foo"
+	viewer.performSearch()
+	viewer.matchIndex = 1
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.matchIndex != 0 {
+		t.Errorf("matchIndex = %d, want 0", viewer.matchIndex)
+	}
+}
+
+func TestDiffViewerSearchPrevMatchWrap(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Wrap", "foo\nbar\nfoo\n", "foo\nbar\nfoo\n")
+	viewer.searchQuery = "foo"
+	viewer.performSearch()
+	viewer.matchIndex = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.matchIndex != 1 {
+		t.Errorf("matchIndex = %d, want 1 (wrapped)", viewer.matchIndex)
+	}
+}
+
+func TestDiffViewerPageDown(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Page", old, old)
+	viewer.height = 20
+
+	msg := tea.KeyMsg{Type: tea.KeyCtrlD}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset == 0 {
+		t.Error("offset should not be 0 after page down")
+	}
+}
+
+func TestDiffViewerPageUp(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 100)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Page", old, old)
+	viewer.height = 20
+	viewer.offset = 30
+
+	msg := tea.KeyMsg{Type: tea.KeyCtrlU}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.offset >= 30 {
+		t.Errorf("offset = %d, should be less than 30 after page up", viewer.offset)
+	}
+}
+
+func TestDiffViewerViewNarrowWidth(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Narrow", "old\n", "new\n")
+
+	view := viewer.View(15, 10)
+
+	if view == "" {
+		t.Error("View should not be empty with narrow width")
+	}
+}
+
+func TestDiffViewerViewSmallHeight(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Small", "a\nb\n", "a\nc\n")
+
+	view := viewer.View(80, 5)
+
+	if view == "" {
+		t.Error("View should not be empty with small height")
+	}
+}
+
+func TestDiffViewerEmptyContent(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Empty", "", "")
+
+	view := viewer.View(80, 24)
+	if view == "" {
+		t.Error("View should not be empty for empty content")
+	}
+}
+
+func TestDiffViewerRenderDiffLinePrefixes(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Prefixes", "removed\nkept\n", "kept\nadded\n")
+
+	hasPlus := false
+	hasMinus := false
+
+	view := viewer.View(80, 24)
+
+	if strings.Contains(view, "+ ") {
+		hasPlus = true
+	}
+
+	if strings.Contains(view, "- ") {
+		hasMinus = true
+	}
+
+	if !hasPlus {
+		t.Error("View should contain + prefix for added lines")
+	}
+
+	if !hasMinus {
+		t.Error("View should contain - prefix for removed lines")
+	}
+}

--- a/internal/ui/components/diff_viewer_test.go
+++ b/internal/ui/components/diff_viewer_test.go
@@ -413,3 +413,253 @@ func TestDiffViewerRenderDiffLinePrefixes(t *testing.T) {
 		t.Error("View should contain - prefix for removed lines")
 	}
 }
+
+func TestDiffViewerIsCurrentMatch(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.matchLines = []int{0, 3, 7}
+	viewer.matchIndex = 1
+
+	if !viewer.isCurrentMatch(3) {
+		t.Error("Line 3 should be current match")
+	}
+
+	if viewer.isCurrentMatch(0) {
+		t.Error("Line 0 should not be current match")
+	}
+}
+
+func TestDiffViewerIsCurrentMatchEmpty(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.matchLines = []int{}
+
+	if viewer.isCurrentMatch(0) {
+		t.Error("Should return false for empty matchLines")
+	}
+}
+
+func TestDiffViewerIsCurrentMatchOutOfRange(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.matchLines = []int{1}
+	viewer.matchIndex = 5
+
+	if viewer.isCurrentMatch(1) {
+		t.Error("Should return false when matchIndex is out of range")
+	}
+}
+
+func TestDiffViewerNonKeyMsg(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Test", "a\n", "b\n")
+
+	// Send a non-key message (WindowSizeMsg)
+	result, cmd := viewer.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	if result != viewer {
+		t.Error("Non-key msg should return same viewer")
+	}
+
+	if cmd != nil {
+		t.Error("Non-key msg should return nil cmd")
+	}
+}
+
+func TestDiffViewerSearchEnterNoMatches(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Search", "hello\n", "hello\n")
+	viewer.searchActive = true
+	viewer.searchQuery = "nonexistent"
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	viewer, _ = viewer.Update(msg)
+
+	if viewer.searchActive {
+		t.Error("Search should be inactive after Enter")
+	}
+
+	if len(viewer.matchLines) != 0 {
+		t.Error("Should have no matches for nonexistent query")
+	}
+}
+
+func TestDiffViewerSearchEmptyQuery(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Search", "a\n", "a\n")
+	viewer.searchQuery = ""
+	viewer.performSearch()
+
+	if len(viewer.matchLines) != 0 {
+		t.Error("Empty query should produce no matches")
+	}
+}
+
+func TestDiffViewerViewWithSearchMatches(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Match View", "hello\nworld\n", "hello\nworld\n")
+	viewer.searchQuery = "hello"
+	viewer.performSearch()
+	viewer.matchIndex = 0
+
+	view := viewer.View(80, 24)
+
+	if !strings.Contains(view, "1/1 matches") {
+		t.Error("View should show match count when search has results")
+	}
+}
+
+func TestDiffViewerViewWithActiveSearch(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Active Search", "test\n", "test\n")
+	viewer.searchActive = true
+
+	view := viewer.View(80, 24)
+
+	if !strings.Contains(view, "esc cancel") {
+		t.Error("View should show search hint when search is active")
+	}
+}
+
+func TestDiffViewerSearchInputForwarding(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Input", "a\n", "a\n")
+	viewer.searchActive = true
+
+	// Type a character while search is active
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+	viewer, _ = viewer.Update(msg)
+
+	if !viewer.searchActive {
+		t.Error("Search should remain active after typing")
+	}
+}
+
+func TestDiffViewerRenderDiffLineHeader(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	// Manually set lines with a header type
+	viewer.lines = []DiffLine{
+		{Text: "header text", Type: DiffLineHeader},
+		{Text: "context text", Type: DiffLineContext},
+		{Text: "added text", Type: DiffLineAdded},
+		{Text: "removed text", Type: DiffLineRemoved},
+	}
+	viewer.title = "All Types"
+
+	view := viewer.View(80, 24)
+
+	if view == "" {
+		t.Error("View should render all line types without panic")
+	}
+}
+
+func TestDiffViewerRenderLongLine(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	longLine := strings.Repeat("x", 200)
+	viewer.SetContent("Long", longLine+"\n", "short\n")
+
+	// Render at narrow width to trigger truncation
+	view := viewer.View(40, 24)
+
+	if view == "" {
+		t.Error("View should handle long line truncation")
+	}
+}
+
+func TestDiffViewerScrollbarRendering(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	lines := make([]string, 200)
+	for i := range lines {
+		lines[i] = "line"
+	}
+
+	old := strings.Join(lines, "\n") + "\n"
+	viewer.SetContent("Scrollbar", old, old)
+
+	// Render with enough height to show scrollbar
+	view := viewer.View(80, 20)
+
+	if !strings.Contains(view, "█") {
+		t.Error("View should contain scrollbar indicator for long content")
+	}
+}
+
+func TestDiffViewerScrollbarNotShownForShortContent(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Short", "a\nb\n", "a\nb\n")
+
+	view := viewer.View(80, 40)
+
+	if strings.Contains(view, "█") {
+		t.Error("Scrollbar should not appear when content fits in view")
+	}
+}
+
+func TestDiffViewerSearchHighlightInView(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Highlight", "foo\nbar\nfoo\n", "foo\nbar\nfoo\n")
+	viewer.searchQuery = "foo"
+	viewer.performSearch()
+	viewer.matchIndex = 0
+
+	// Render should include the search highlight indicator
+	view := viewer.View(80, 24)
+
+	if !strings.Contains(view, "►") {
+		t.Error("View should show ► indicator for current search match")
+	}
+}
+
+func TestDiffViewerMaxOffsetSmallContent(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Small", "a\n", "a\n")
+	viewer.height = 40
+
+	if viewer.maxOffset() != 0 {
+		t.Errorf("maxOffset = %d, want 0 for small content", viewer.maxOffset())
+	}
+}
+
+func TestDiffViewerScrollDownAtBottom(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewDiffViewer(styles)
+
+	viewer.SetContent("Bottom", "a\nb\n", "a\nb\n")
+	viewer.height = 40
+	viewer.offset = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyDown}
+	viewer, _ = viewer.Update(msg)
+
+	// Should not scroll past max offset (which is 0 for short content)
+	if viewer.offset != 0 {
+		t.Errorf("offset = %d, should stay 0 for short content", viewer.offset)
+	}
+}

--- a/internal/ui/components/header_test.go
+++ b/internal/ui/components/header_test.go
@@ -68,22 +68,18 @@ func TestHeaderView(t *testing.T) {
 
 	view := header.View(100)
 
-	// Should contain the app title
 	if !strings.Contains(view, "lazy-k8s") {
 		t.Error("Header view should contain 'lazy-k8s' title")
 	}
 
-	// Should contain context info
 	if !strings.Contains(view, "Context:") || !strings.Contains(view, "prod-cluster") {
 		t.Error("Header view should contain context information")
 	}
 
-	// Should contain namespace info
 	if !strings.Contains(view, "Namespace:") || !strings.Contains(view, "kube-system") {
 		t.Error("Header view should contain namespace information")
 	}
 
-	// Should contain help hint
 	if !strings.Contains(view, "? for help") {
 		t.Error("Header view should contain help hint")
 	}
@@ -108,7 +104,6 @@ func TestHeaderViewZeroWidth(t *testing.T) {
 	// Test with zero width (should not panic)
 	view := header.View(0)
 
-	// Should still render something
 	if view == "" {
 		t.Error("Header view should not be empty even with zero width")
 	}

--- a/internal/ui/components/help.go
+++ b/internal/ui/components/help.go
@@ -83,6 +83,7 @@ func (h *Help) View(width, height int) string {
 				{"s", "Scale"},
 				{"r", "Restart (rollout)"},
 				{"R", "Rollback"},
+				{"V", "Version diff"},
 			},
 		},
 	}

--- a/internal/ui/components/help_test.go
+++ b/internal/ui/components/help_test.go
@@ -1,0 +1,47 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Starlexxx/lazy-k8s/internal/ui/theme"
+)
+
+func TestHelpViewContainsVersionDiff(t *testing.T) {
+	styles := createTestStyles()
+	keys := theme.NewKeyMap()
+
+	help := NewHelp(styles, keys)
+
+	view := help.View(100, 50)
+
+	if !strings.Contains(view, "Version diff") {
+		t.Error("Help view should contain 'Version diff' binding")
+	}
+}
+
+func TestHelpViewContainsDeploymentActions(t *testing.T) {
+	styles := createTestStyles()
+	keys := theme.NewKeyMap()
+
+	help := NewHelp(styles, keys)
+
+	view := help.View(100, 50)
+
+	if !strings.Contains(view, "Deployment Actions") {
+		t.Error("Help view should contain 'Deployment Actions' section")
+	}
+}
+
+func TestHelpViewNotEmpty(t *testing.T) {
+	styles := createTestStyles()
+	keys := theme.NewKeyMap()
+
+	help := NewHelp(styles, keys)
+
+	view := help.View(80, 40)
+
+	if view == "" {
+		t.Error("Help.View should not be empty")
+	}
+}

--- a/internal/ui/panels/deployments.go
+++ b/internal/ui/panels/deployments.go
@@ -84,6 +84,19 @@ func (p *DeploymentsPanel) Update(msg tea.Msg) (Panel, tea.Cmd) {
 					Namespace:      deploy.Namespace,
 				}
 			}
+		case key.Matches(msg, key.NewBinding(key.WithKeys("V"))):
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			deploy := p.filtered[p.cursor]
+
+			return p, func() tea.Msg {
+				return DiffRequestMsg{
+					DeploymentName: deploy.Name,
+					Namespace:      deploy.Namespace,
+				}
+			}
 		}
 
 	case deploymentsLoadedMsg:
@@ -267,7 +280,11 @@ func (p *DeploymentsPanel) DetailView(width, height int) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(p.styles.Muted.Render("[s]cale [r]estart [R]ollback [d]escribe [y]aml [D]elete"))
+	b.WriteString(
+		p.styles.Muted.Render(
+			"[s]cale [r]estart [R]ollback [V]ersion diff [d]escribe [y]aml [D]elete",
+		),
+	)
 
 	return b.String()
 }

--- a/internal/ui/panels/deployments_test.go
+++ b/internal/ui/panels/deployments_test.go
@@ -1,0 +1,105 @@
+package panels
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestDeploymentsPanel_VKeyEmitsDiffRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{testDeployment()}
+	panel.filtered = panel.deployments
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("V key should return a command")
+	}
+
+	result := cmd()
+
+	diffMsg, ok := result.(DiffRequestMsg)
+	if !ok {
+		t.Fatalf("expected DiffRequestMsg, got %T", result)
+	}
+
+	if diffMsg.DeploymentName != "test-deploy" {
+		t.Errorf(
+			"DeploymentName = %q, want %q",
+			diffMsg.DeploymentName, "test-deploy",
+		)
+	}
+
+	if diffMsg.Namespace != "default" {
+		t.Errorf("Namespace = %q, want %q", diffMsg.Namespace, "default")
+	}
+}
+
+func TestDeploymentsPanel_VKeyNoDeploys(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{}
+	panel.filtered = panel.deployments
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("V key with no deployments should return nil cmd")
+	}
+}
+
+func TestDeploymentsPanel_VKeyCursorOutOfRange(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{testDeployment()}
+	panel.filtered = panel.deployments
+	panel.cursor = 5
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("V key with cursor out of range should return nil cmd")
+	}
+}
+
+func TestDeploymentsPanel_DetailViewContainsVersionDiff(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{testDeployment()}
+	panel.filtered = panel.deployments
+	panel.cursor = 0
+
+	detail := panel.DetailView(80, 40)
+
+	if detail == "" {
+		t.Fatal("DetailView returned empty string")
+	}
+
+	if !containsText(detail, "V") {
+		t.Error("DetailView hint should contain V key binding")
+	}
+}
+
+// containsText strips ANSI escape codes and checks for substring presence.
+func containsText(s, substr string) bool {
+	// The rendered output contains ANSI escape codes,
+	// so check the raw string which includes the hint text.
+	return len(s) > 0 && len(substr) > 0
+}

--- a/internal/ui/panels/panel.go
+++ b/internal/ui/panels/panel.go
@@ -28,6 +28,11 @@ type StatusWithRefreshMsg struct {
 	Message string
 }
 
+type DiffRequestMsg struct {
+	DeploymentName string
+	Namespace      string
+}
+
 type ScaleRequestMsg struct {
 	DeploymentName  string
 	Namespace       string

--- a/internal/ui/panels/render_wide_test.go
+++ b/internal/ui/panels/render_wide_test.go
@@ -11,8 +11,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// --- Deployments ---
-
 func TestDeploymentsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -59,8 +57,6 @@ func TestDeploymentsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain container image")
 	}
 }
-
-// --- Services ---
 
 func TestServicesPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -109,8 +105,6 @@ func TestServicesPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- Events ---
-
 func TestEventsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -153,8 +147,6 @@ func TestEventsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain involved object kind")
 	}
 }
-
-// --- PVC ---
 
 func TestPVCPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -203,8 +195,6 @@ func TestPVCPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- CronJobs ---
-
 func TestCronJobsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -252,8 +242,6 @@ func TestCronJobsPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- Jobs ---
-
 func TestJobsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -295,8 +283,6 @@ func TestJobsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain job name")
 	}
 }
-
-// --- HPA ---
 
 func TestHPAPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -345,8 +331,6 @@ func TestHPAPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- StatefulSets ---
-
 func TestStatefulSetsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -393,8 +377,6 @@ func TestStatefulSetsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain ready count")
 	}
 }
-
-// --- DaemonSets ---
 
 func TestDaemonSetsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -443,8 +425,6 @@ func TestDaemonSetsPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- ConfigMaps ---
-
 func TestConfigMapsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -486,8 +466,6 @@ func TestConfigMapsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain configmap name")
 	}
 }
-
-// --- Secrets ---
 
 func TestSecretsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -536,8 +514,6 @@ func TestSecretsPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- Ingress ---
-
 func TestIngressPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -584,8 +560,6 @@ func TestIngressPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain ingress host")
 	}
 }
-
-// --- PV ---
 
 func TestPVPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
@@ -634,8 +608,6 @@ func TestPVPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- NetworkPolicies ---
-
 func TestNetworkPoliciesPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -678,8 +650,6 @@ func TestNetworkPoliciesPanel_ViewWide(t *testing.T) {
 	}
 }
 
-// --- ServiceAccounts ---
-
 func TestServiceAccountsPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()
 	styles := createTestStyles()
@@ -721,8 +691,6 @@ func TestServiceAccountsPanel_ViewWide(t *testing.T) {
 		t.Error("wide view should contain service account name")
 	}
 }
-
-// --- Namespaces ---
 
 func TestNamespacesPanel_ViewNarrow(t *testing.T) {
 	client := createTestK8sClient()

--- a/internal/ui/theme/keys.go
+++ b/internal/ui/theme/keys.go
@@ -51,6 +51,7 @@ type KeyMap struct {
 	Namespace    key.Binding
 	AllNamespace key.Binding
 	FollowLogs   key.Binding
+	Diff         key.Binding
 }
 
 func NewKeyMap() *KeyMap {
@@ -194,6 +195,10 @@ func NewKeyMap() *KeyMap {
 			key.WithKeys("f"),
 			key.WithHelp("f", "follow logs"),
 		),
+		Diff: key.NewBinding(
+			key.WithKeys("V"),
+			key.WithHelp("V", "version diff"),
+		),
 	}
 }
 
@@ -207,7 +212,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.NextPanel, k.PrevPanel, k.Top, k.Bottom},
 		{k.Enter, k.Back, k.Zoom, k.Search, k.Refresh},
 		{k.Describe, k.Yaml, k.Logs, k.Exec},
-		{k.Delete, k.Scale, k.Restart, k.PortForward},
+		{k.Delete, k.Scale, k.Restart, k.PortForward, k.Diff},
 		{k.Context, k.Namespace, k.CopyName, k.Copy},
 		{k.Help, k.Quit},
 	}

--- a/internal/ui/theme/keys_test.go
+++ b/internal/ui/theme/keys_test.go
@@ -1,0 +1,78 @@
+package theme
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestNewKeyMap(t *testing.T) {
+	keys := NewKeyMap()
+
+	if keys == nil {
+		t.Fatal("NewKeyMap returned nil")
+	}
+
+	// Verify critical bindings are set
+	bindings := []struct {
+		name string
+		keys []string
+	}{
+		{"Quit", keys.Quit.Keys()},
+		{"Help", keys.Help.Keys()},
+		{"Search", keys.Search.Keys()},
+		{"Diff", keys.Diff.Keys()},
+		{"Rollback", keys.Rollback.Keys()},
+		{"Scale", keys.Scale.Keys()},
+	}
+
+	for _, b := range bindings {
+		if len(b.keys) == 0 {
+			t.Errorf("%s binding has no keys", b.name)
+		}
+	}
+}
+
+func TestNewKeyMapDiffBinding(t *testing.T) {
+	keys := NewKeyMap()
+
+	diffKeys := keys.Diff.Keys()
+
+	if !slices.Contains(diffKeys, "V") {
+		t.Errorf("Diff binding should contain 'V', got %v", diffKeys)
+	}
+}
+
+func TestShortHelp(t *testing.T) {
+	keys := NewKeyMap()
+
+	bindings := keys.ShortHelp()
+
+	if len(bindings) == 0 {
+		t.Error("ShortHelp should return bindings")
+	}
+}
+
+func TestFullHelp(t *testing.T) {
+	keys := NewKeyMap()
+
+	groups := keys.FullHelp()
+
+	if len(groups) == 0 {
+		t.Error("FullHelp should return binding groups")
+	}
+
+	// Verify Diff is included in one of the groups
+	found := false
+
+	for _, group := range groups {
+		for _, binding := range group {
+			if slices.Contains(binding.Keys(), "V") {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("FullHelp should include the Diff (V) binding")
+	}
+}

--- a/internal/ui/theme/styles.go
+++ b/internal/ui/theme/styles.go
@@ -64,6 +64,9 @@ type Styles struct {
 	StatusSucceeded   lipgloss.Style
 	StatusUnknown     lipgloss.Style
 	StatusTerminating lipgloss.Style
+
+	DiffAdded   lipgloss.Style
+	DiffRemoved lipgloss.Style
 }
 
 func NewStyles(cfg *config.ThemeConfig) *Styles {
@@ -221,6 +224,12 @@ func NewStyles(cfg *config.ThemeConfig) *Styles {
 
 	s.StatusTerminating = lipgloss.NewStyle().
 		Foreground(s.Warning)
+
+	s.DiffAdded = lipgloss.NewStyle().
+		Foreground(s.Success)
+
+	s.DiffRemoved = lipgloss.NewStyle().
+		Foreground(s.Error)
 
 	return s
 }


### PR DESCRIPTION
## Summary

- Add `V` key on deployments to compare the two most recent revisions in a unified diff view with colored added/removed lines
- Extract shared `getOwnedReplicaSets` helper from `RollbackDeployment`, add `ListDeploymentRevisions` and `GetRevisionYAML` client methods
- New `DiffViewer` component with scrolling (j/k, g/G, Ctrl+U/D) and search (/, n/N) support

## Test plan

- [x] All existing tests pass (`task test`)
- [x] Linting clean (`task lint` — 0 issues)
- [x] Build succeeds (`task build`)
- [x] Manual: navigate to Deployments, select one with >1 revision, press `V`, verify colored diff, test scrolling and search