### PR TITLE
Add operations history with undo support

### DIFF
--- a/internal/ui/components/history.go
+++ b/internal/ui/components/history.go
@@ -1,0 +1,152 @@
+package components
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// OperationType categorizes each recorded operation.
+type OperationType int
+
+const (
+	OpScaleDeployment OperationType = iota
+	OpScaleStatefulSet
+	OpRestartDeployment
+	OpRestartStatefulSet
+	OpRestartDaemonSet
+	OpRollbackDeployment
+	OpDeleteResource
+	OpPortForward
+	OpExec
+	OpSuspendCronJob
+	OpResumeCronJob
+	OpEditHPAMin
+	OpEditHPAMax
+	OpEditResource
+	OpTriggerCronJob
+)
+
+// UndoData captures previous state needed to reverse an operation.
+// Uses a flat struct to avoid type assertions (forcetypeassert linter).
+type UndoData struct {
+	PreviousReplicas    int32
+	PreviousSuspend     bool
+	PreviousMinReplicas int32
+	PreviousMaxReplicas int32
+}
+
+// OperationRecord represents a single logged operation.
+type OperationRecord struct {
+	ID        int
+	Type      OperationType
+	Timestamp time.Time
+	Resource  string // e.g. "deployment/nginx"
+	Namespace string
+	Message   string // human-readable summary
+	Undoable  bool
+	UndoData  UndoData
+	Undone    bool
+}
+
+// HistoryStore is an append-only in-memory log of operations.
+// Safe for concurrent use from tea.Cmd goroutines.
+type HistoryStore struct {
+	mu      sync.Mutex
+	records []OperationRecord
+	nextID  int
+}
+
+func NewHistoryStore() *HistoryStore {
+	return &HistoryStore{
+		records: make([]OperationRecord, 0),
+	}
+}
+
+// Add appends a record and returns its assigned ID.
+func (h *HistoryStore) Add(rec OperationRecord) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	rec.ID = h.nextID
+	h.nextID++
+
+	if rec.Timestamp.IsZero() {
+		rec.Timestamp = time.Now()
+	}
+
+	h.records = append(h.records, rec)
+
+	return rec.ID
+}
+
+// Records returns all entries newest-first.
+func (h *HistoryStore) Records() []OperationRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	out := make([]OperationRecord, len(h.records))
+
+	for i, rec := range h.records {
+		out[len(h.records)-1-i] = rec
+	}
+
+	return out
+}
+
+// Get returns the record with the given ID, if it exists.
+func (h *HistoryStore) Get(id int) (OperationRecord, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if id < 0 || id >= len(h.records) {
+		return OperationRecord{}, false
+	}
+
+	return h.records[id], true
+}
+
+// MarkUndone flags a record as having been undone.
+func (h *HistoryStore) MarkUndone(id int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if id >= 0 && id < len(h.records) {
+		h.records[id].Undone = true
+	}
+}
+
+// Len returns the total number of recorded operations.
+func (h *HistoryStore) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return len(h.records)
+}
+
+// operationLabel returns a human-readable label for the operation type.
+func operationLabel(op OperationType) string {
+	labels := map[OperationType]string{
+		OpScaleDeployment:    "Scale Deployment",
+		OpScaleStatefulSet:   "Scale StatefulSet",
+		OpRestartDeployment:  "Restart Deployment",
+		OpRestartStatefulSet: "Restart StatefulSet",
+		OpRestartDaemonSet:   "Restart DaemonSet",
+		OpRollbackDeployment: "Rollback Deployment",
+		OpDeleteResource:     "Delete",
+		OpPortForward:        "Port Forward",
+		OpExec:               "Exec",
+		OpSuspendCronJob:     "Suspend CronJob",
+		OpResumeCronJob:      "Resume CronJob",
+		OpEditHPAMin:         "Edit HPA Min",
+		OpEditHPAMax:         "Edit HPA Max",
+		OpEditResource:       "Edit Resource",
+		OpTriggerCronJob:     "Trigger CronJob",
+	}
+
+	if label, ok := labels[op]; ok {
+		return label
+	}
+
+	return fmt.Sprintf("Unknown(%d)", op)
+}

--- a/internal/ui/components/history_test.go
+++ b/internal/ui/components/history_test.go
@@ -1,0 +1,174 @@
+package components
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHistoryStore_AddAndGet(t *testing.T) {
+	t.Parallel()
+
+	store := NewHistoryStore()
+
+	id := store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Message:   "Scaled nginx from 1 to 3 replicas",
+		Undoable:  true,
+		UndoData:  UndoData{PreviousReplicas: 1},
+	})
+
+	if id != 0 {
+		t.Errorf("expected first ID = 0, got %d", id)
+	}
+
+	if store.Len() != 1 {
+		t.Errorf("expected Len() = 1, got %d", store.Len())
+	}
+
+	rec, ok := store.Get(id)
+	if !ok {
+		t.Fatal("expected Get to return true")
+	}
+
+	if rec.Resource != "nginx" {
+		t.Errorf("expected Resource = nginx, got %s", rec.Resource)
+	}
+
+	if rec.UndoData.PreviousReplicas != 1 {
+		t.Errorf(
+			"expected PreviousReplicas = 1, got %d",
+			rec.UndoData.PreviousReplicas,
+		)
+	}
+}
+
+func TestHistoryStore_RecordsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "first",
+		Namespace: "default",
+		Timestamp: time.Now().Add(-time.Minute),
+	})
+
+	store.Add(OperationRecord{
+		Type:      OpRestartDeployment,
+		Resource:  "second",
+		Namespace: "default",
+	})
+
+	records := store.Records()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	// Newest first
+	if records[0].Resource != "second" {
+		t.Errorf("expected first record = second, got %s", records[0].Resource)
+	}
+
+	if records[1].Resource != "first" {
+		t.Errorf("expected second record = first, got %s", records[1].Resource)
+	}
+}
+
+func TestHistoryStore_MarkUndone(t *testing.T) {
+	t.Parallel()
+
+	store := NewHistoryStore()
+
+	id := store.Add(OperationRecord{
+		Type:      OpSuspendCronJob,
+		Resource:  "cleanup",
+		Namespace: "default",
+		Undoable:  true,
+	})
+
+	store.MarkUndone(id)
+
+	rec, ok := store.Get(id)
+	if !ok {
+		t.Fatal("expected Get to return true")
+	}
+
+	if !rec.Undone {
+		t.Error("expected record to be marked as undone")
+	}
+}
+
+func TestHistoryStore_GetInvalidID(t *testing.T) {
+	t.Parallel()
+
+	store := NewHistoryStore()
+
+	_, ok := store.Get(-1)
+	if ok {
+		t.Error("expected Get(-1) to return false")
+	}
+
+	_, ok = store.Get(999)
+	if ok {
+		t.Error("expected Get(999) to return false")
+	}
+}
+
+func TestHistoryStore_TimestampAutoSet(t *testing.T) {
+	t.Parallel()
+
+	store := NewHistoryStore()
+
+	before := time.Now()
+
+	store.Add(OperationRecord{
+		Type:      OpDeleteResource,
+		Resource:  "pod/test",
+		Namespace: "default",
+	})
+
+	after := time.Now()
+
+	rec, _ := store.Get(0)
+	if rec.Timestamp.Before(before) || rec.Timestamp.After(after) {
+		t.Error("expected timestamp to be auto-set to current time")
+	}
+}
+
+func TestOperationLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		op    OperationType
+		label string
+	}{
+		{OpScaleDeployment, "Scale Deployment"},
+		{OpRestartDaemonSet, "Restart DaemonSet"},
+		{OpDeleteResource, "Delete"},
+		{OpSuspendCronJob, "Suspend CronJob"},
+		{OpResumeCronJob, "Resume CronJob"},
+		{OpEditResource, "Edit Resource"},
+		{OpTriggerCronJob, "Trigger CronJob"},
+	}
+
+	for _, tt := range tests {
+		if got := operationLabel(tt.op); got != tt.label {
+			t.Errorf(
+				"operationLabel(%d) = %q, want %q",
+				tt.op, got, tt.label,
+			)
+		}
+	}
+}
+
+func TestOperationLabel_Unknown(t *testing.T) {
+	t.Parallel()
+
+	label := operationLabel(OperationType(999))
+	if label != "Unknown(999)" {
+		t.Errorf("expected Unknown(999), got %q", label)
+	}
+}

--- a/internal/ui/components/history_viewer.go
+++ b/internal/ui/components/history_viewer.go
@@ -1,0 +1,234 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Starlexxx/lazy-k8s/internal/ui/theme"
+)
+
+// UndoRequestMsg is returned by the history viewer when the user
+// presses 'u' on an undoable operation entry.
+type UndoRequestMsg struct {
+	RecordID int
+}
+
+// HistoryViewer renders a scrollable full-screen list of past operations
+// with undo support for reversible entries.
+type HistoryViewer struct {
+	styles *theme.Styles
+	store  *HistoryStore
+	cursor int
+	offset int
+	width  int
+	height int
+}
+
+func NewHistoryViewer(
+	styles *theme.Styles,
+	store *HistoryStore,
+) *HistoryViewer {
+	return &HistoryViewer{
+		styles: styles,
+		store:  store,
+	}
+}
+
+// Reset returns cursor and scroll to the top.
+func (h *HistoryViewer) Reset() {
+	h.cursor = 0
+	h.offset = 0
+}
+
+func (h *HistoryViewer) Update(msg tea.Msg) (*HistoryViewer, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return h, nil
+	}
+
+	records := h.store.Records()
+
+	switch keyMsg.String() {
+	case "up", "k":
+		if h.cursor > 0 {
+			h.cursor--
+			h.ensureVisible()
+		}
+	case "down", "j":
+		if h.cursor < len(records)-1 {
+			h.cursor++
+			h.ensureVisible()
+		}
+	case "g":
+		h.cursor = 0
+		h.offset = 0
+	case "G":
+		h.cursor = max(len(records)-1, 0)
+		h.ensureVisible()
+	case "pgup", "ctrl+u":
+		h.cursor -= h.visibleHeight() / 2
+		if h.cursor < 0 {
+			h.cursor = 0
+		}
+
+		h.ensureVisible()
+	case "pgdown", "ctrl+d":
+		h.cursor += h.visibleHeight() / 2
+		if h.cursor >= len(records) {
+			h.cursor = max(len(records)-1, 0)
+		}
+
+		h.ensureVisible()
+	case "u":
+		if h.cursor < len(records) {
+			rec := records[h.cursor]
+			if rec.Undoable && !rec.Undone {
+				return h, func() tea.Msg {
+					return UndoRequestMsg{RecordID: rec.ID}
+				}
+			}
+		}
+	}
+
+	return h, nil
+}
+
+func (h *HistoryViewer) visibleHeight() int {
+	// Title (1) + separator (1) + hint (1) + modal padding (~4)
+	const overhead = 7
+
+	return max(h.height-overhead, 1)
+}
+
+func (h *HistoryViewer) ensureVisible() {
+	vis := h.visibleHeight()
+
+	if h.cursor < h.offset {
+		h.offset = h.cursor
+	}
+
+	if h.cursor >= h.offset+vis {
+		h.offset = h.cursor - vis + 1
+	}
+}
+
+func (h *HistoryViewer) View(width, height int) string {
+	h.width = width
+	h.height = height
+
+	records := h.store.Records()
+
+	var b strings.Builder
+
+	title := h.styles.ModalTitle.Render("Operations History")
+	countLabel := h.styles.Muted.Render(
+		fmt.Sprintf("(%d operations)", len(records)),
+	)
+	hint := h.styles.Muted.Render(
+		"↑/↓ navigate • u undo • esc close",
+	)
+	titleBar := lipgloss.JoinHorizontal(
+		lipgloss.Center, title, " ", countLabel, "  ", hint,
+	)
+
+	b.WriteString(titleBar)
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("─", width-4))
+	b.WriteString("\n")
+
+	if len(records) == 0 {
+		b.WriteString(h.styles.Muted.Render("  No operations recorded yet."))
+		b.WriteString("\n")
+	} else {
+		vis := h.visibleHeight()
+		endIdx := min(h.offset+vis, len(records))
+
+		maxLineWidth := width - 8
+
+		for i := h.offset; i < endIdx; i++ {
+			line := h.renderRecord(records[i], i == h.cursor, maxLineWidth)
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+
+		h.renderScrollbar(&b, vis, width, len(records))
+	}
+
+	return h.styles.Modal.
+		Width(width - 4).
+		Height(height - 2).
+		Render(b.String())
+}
+
+func (h *HistoryViewer) renderRecord(
+	rec OperationRecord,
+	selected bool,
+	maxWidth int,
+) string {
+	ts := rec.Timestamp.Format("15:04:05")
+	label := operationLabel(rec.Type)
+
+	var undoTag string
+	if rec.Undone {
+		undoTag = " [undone]"
+	} else if rec.Undoable {
+		undoTag = " [undo]"
+	}
+
+	line := fmt.Sprintf(
+		"%s  %-22s  %s/%s%s",
+		ts, label, rec.Namespace, rec.Resource, undoTag,
+	)
+
+	if len(line) > maxWidth {
+		line = line[:maxWidth-3] + "..."
+	}
+
+	if selected {
+		return h.styles.ListItemFocused.Render("► " + line)
+	}
+
+	if rec.Undone {
+		return h.styles.Muted.Render("  " + line)
+	}
+
+	return lipgloss.NewStyle().
+		Foreground(h.styles.Text).
+		Render("  " + line)
+}
+
+func (h *HistoryViewer) renderScrollbar(
+	b *strings.Builder,
+	visibleHeight, width, totalItems int,
+) {
+	if totalItems <= visibleHeight || width <= 12 {
+		return
+	}
+
+	scrollPos := float64(h.offset) / float64(totalItems-visibleHeight)
+	barWidth := width - 10
+
+	leftWidth := max(int(float64(barWidth)*scrollPos), 0)
+	leftWidth = min(leftWidth, barWidth)
+
+	rightWidth := max(barWidth-leftWidth-1, 0)
+
+	indicator := strings.Repeat("─", leftWidth) + "█" +
+		strings.Repeat("─", rightWidth)
+
+	b.WriteString("\n")
+	b.WriteString(h.styles.Muted.Render(indicator))
+}
+
+// SelectedRecord returns the record currently under the cursor.
+func (h *HistoryViewer) SelectedRecord() (OperationRecord, bool) {
+	records := h.store.Records()
+	if h.cursor < 0 || h.cursor >= len(records) {
+		return OperationRecord{}, false
+	}
+
+	return records[h.cursor], true
+}

--- a/internal/ui/components/history_viewer_test.go
+++ b/internal/ui/components/history_viewer_test.go
@@ -1,0 +1,400 @@
+package components
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestHistoryViewer_Navigation(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type: OpScaleDeployment, Resource: "a", Namespace: "ns",
+	})
+	store.Add(OperationRecord{
+		Type: OpRestartDeployment, Resource: "b", Namespace: "ns",
+	})
+	store.Add(OperationRecord{
+		Type: OpDeleteResource, Resource: "c", Namespace: "ns",
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+
+	// Starts at cursor 0 (newest item)
+	rec, ok := viewer.SelectedRecord()
+	if !ok {
+		t.Fatal("expected selected record")
+	}
+
+	if rec.Resource != "c" {
+		t.Errorf("expected resource c (newest), got %s", rec.Resource)
+	}
+
+	// Move down
+	viewer, _ = viewer.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+
+	rec, _ = viewer.SelectedRecord()
+	if rec.Resource != "b" {
+		t.Errorf("expected resource b, got %s", rec.Resource)
+	}
+
+	// Move to bottom
+	viewer, _ = viewer.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+
+	rec, _ = viewer.SelectedRecord()
+	if rec.Resource != "a" {
+		t.Errorf("expected resource a (oldest), got %s", rec.Resource)
+	}
+
+	// Move to top
+	viewer, _ = viewer.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+
+	rec, _ = viewer.SelectedRecord()
+	if rec.Resource != "c" {
+		t.Errorf("expected resource c, got %s", rec.Resource)
+	}
+}
+
+func TestHistoryViewer_UndoRequest(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Undoable:  true,
+		UndoData:  UndoData{PreviousReplicas: 2},
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+
+	// Press 'u' on undoable record
+	_, cmd := viewer.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}},
+	)
+
+	if cmd == nil {
+		t.Fatal("expected undo command to be returned")
+	}
+
+	msg := cmd()
+	undoMsg, ok := msg.(UndoRequestMsg)
+
+	if !ok {
+		t.Fatalf("expected UndoRequestMsg, got %T", msg)
+	}
+
+	if undoMsg.RecordID != 0 {
+		t.Errorf("expected record ID 0, got %d", undoMsg.RecordID)
+	}
+}
+
+func TestHistoryViewer_UndoNotAvailableForUndone(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	id := store.Add(OperationRecord{
+		Type:     OpScaleDeployment,
+		Resource: "nginx",
+		Undoable: true,
+	})
+
+	store.MarkUndone(id)
+
+	viewer := NewHistoryViewer(styles, store)
+	_, cmd := viewer.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}},
+	)
+
+	if cmd != nil {
+		t.Error("expected nil cmd for already-undone record")
+	}
+}
+
+func TestHistoryViewer_ViewEmpty(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+	viewer := NewHistoryViewer(styles, store)
+
+	output := viewer.View(80, 24)
+
+	if !strings.Contains(output, "Operations History") {
+		t.Error("expected title in output")
+	}
+
+	if !strings.Contains(output, "No operations recorded") {
+		t.Error("expected empty state message")
+	}
+}
+
+func TestHistoryViewer_ViewWithRecords(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Timestamp: time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC),
+		Undoable:  true,
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+	output := viewer.View(100, 24)
+
+	if !strings.Contains(output, "12:30:00") {
+		t.Error("expected timestamp in output")
+	}
+
+	if !strings.Contains(output, "Scale Deployment") {
+		t.Error("expected operation label in output")
+	}
+
+	if !strings.Contains(output, "nginx") {
+		t.Error("expected resource name in output")
+	}
+
+	if !strings.Contains(output, "[undo]") {
+		t.Error("expected [undo] tag for undoable record")
+	}
+}
+
+func TestHistoryViewer_ViewUndoneRecord(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	id := store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Timestamp: time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC),
+		Undoable:  true,
+	})
+
+	store.MarkUndone(id)
+
+	viewer := NewHistoryViewer(styles, store)
+	output := viewer.View(100, 24)
+
+	if !strings.Contains(output, "[undone]") {
+		t.Error("expected [undone] tag for undone record")
+	}
+}
+
+func TestHistoryViewer_Reset(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	for i := range 5 {
+		store.Add(OperationRecord{
+			Type:     OpDeleteResource,
+			Resource: string(rune('a' + i)),
+		})
+	}
+
+	viewer := NewHistoryViewer(styles, store)
+
+	// Move cursor down
+	viewer, _ = viewer.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}},
+	)
+	viewer, _ = viewer.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}},
+	)
+
+	viewer.Reset()
+
+	if viewer.cursor != 0 {
+		t.Errorf("expected cursor 0 after reset, got %d", viewer.cursor)
+	}
+
+	if viewer.offset != 0 {
+		t.Errorf("expected offset 0 after reset, got %d", viewer.offset)
+	}
+}
+
+func TestHistoryViewer_PageNavigation(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	// Add enough records to require scrolling
+	for i := range 50 {
+		store.Add(OperationRecord{
+			Type:      OpDeleteResource,
+			Resource:  string(rune('a' + (i % 26))),
+			Namespace: "default",
+			Timestamp: time.Now(),
+		})
+	}
+
+	viewer := NewHistoryViewer(styles, store)
+
+	// Must render once to set height so visibleHeight() works
+	viewer.View(100, 20)
+
+	// ctrl+d for page down (matching the handler in history_viewer.go)
+	viewer, _ = viewer.Update(
+		tea.KeyMsg{Type: tea.KeyCtrlD},
+	)
+
+	if viewer.cursor == 0 {
+		t.Error("expected cursor to move after ctrl+d")
+	}
+
+	// ctrl+u for page up
+	prevCursor := viewer.cursor
+
+	viewer, _ = viewer.Update(
+		tea.KeyMsg{Type: tea.KeyCtrlU},
+	)
+
+	if viewer.cursor >= prevCursor {
+		t.Error("expected cursor to move up after ctrl+u")
+	}
+}
+
+func TestHistoryViewer_ScrollbarRendered(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	// Add many records to trigger scrollbar
+	for i := range 50 {
+		store.Add(OperationRecord{
+			Type:      OpDeleteResource,
+			Resource:  string(rune('a' + (i % 26))),
+			Namespace: "default",
+			Timestamp: time.Now(),
+		})
+	}
+
+	viewer := NewHistoryViewer(styles, store)
+	output := viewer.View(100, 20)
+
+	// Scrollbar uses "█" indicator
+	if !strings.Contains(output, "█") {
+		t.Error("expected scrollbar indicator in output")
+	}
+}
+
+func TestHistoryViewer_NonUndoableNoCmd(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:     OpDeleteResource,
+		Resource: "pod",
+		Undoable: false,
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+	_, cmd := viewer.Update(
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}},
+	)
+
+	if cmd != nil {
+		t.Error("expected nil cmd for non-undoable record")
+	}
+}
+
+func TestHistoryViewer_NonKeyMsgIgnored(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+	viewer := NewHistoryViewer(styles, store)
+
+	// Non-key message should be ignored
+	_, cmd := viewer.Update("not a key msg")
+
+	if cmd != nil {
+		t.Error("expected nil cmd for non-key message")
+	}
+}
+
+func TestHistoryViewer_SelectedRecordEmpty(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+	viewer := NewHistoryViewer(styles, store)
+
+	_, ok := viewer.SelectedRecord()
+	if ok {
+		t.Error("expected ok=false for empty store")
+	}
+}
+
+func TestHistoryViewer_RenderNonUndoableRecord(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:      OpRestartDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Timestamp: time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC),
+		Undoable:  false,
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+	output := viewer.View(100, 24)
+
+	if !strings.Contains(output, "Restart Deployment") {
+		t.Error("expected operation label in output")
+	}
+
+	// Non-undoable should not have [undo] tag
+	if strings.Contains(output, "[undo]") {
+		t.Error("non-undoable record should not show [undo] tag")
+	}
+}
+
+func TestHistoryViewer_LineTruncation(t *testing.T) {
+	t.Parallel()
+
+	styles := createTestStyles()
+	store := NewHistoryStore()
+
+	store.Add(OperationRecord{
+		Type:      OpScaleDeployment,
+		Resource:  "very-long-deployment-name-that-exceeds-normal-width",
+		Namespace: "extremely-long-namespace-name",
+		Timestamp: time.Now(),
+		Undoable:  true,
+	})
+
+	viewer := NewHistoryViewer(styles, store)
+
+	// Render at narrow width to trigger truncation
+	output := viewer.View(50, 24)
+	if !strings.Contains(output, "...") {
+		t.Error("expected truncated line with '...'")
+	}
+}

--- a/internal/ui/panels/cronjobs.go
+++ b/internal/ui/panels/cronjobs.go
@@ -51,9 +51,37 @@ func (p *CronJobsPanel) Update(msg tea.Msg) (Panel, tea.Cmd) {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("G"))):
 			p.MoveToBottom(len(p.filtered))
 		case key.Matches(msg, key.NewBinding(key.WithKeys("t"))):
-			return p, p.triggerCronJob()
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			cj := p.filtered[p.cursor]
+
+			return p, func() tea.Msg {
+				return TriggerCronJobRequestMsg{
+					CronJobName: cj.Name,
+					Namespace:   cj.Namespace,
+				}
+			}
 		case key.Matches(msg, key.NewBinding(key.WithKeys("S"))):
-			return p, p.toggleSuspend()
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			cj := p.filtered[p.cursor]
+
+			currentSuspend := false
+			if cj.Spec.Suspend != nil {
+				currentSuspend = *cj.Spec.Suspend
+			}
+
+			return p, func() tea.Msg {
+				return ToggleSuspendCronJobRequestMsg{
+					CronJobName:    cj.Name,
+					Namespace:      cj.Namespace,
+					CurrentSuspend: currentSuspend,
+				}
+			}
 		}
 
 	case cronJobsLoadedMsg:
@@ -315,56 +343,6 @@ func (p *CronJobsPanel) Delete() tea.Cmd {
 		}
 
 		return StatusMsg{Message: fmt.Sprintf("Deleted cronjob: %s", cj.Name)}
-	}
-}
-
-func (p *CronJobsPanel) triggerCronJob() tea.Cmd {
-	if p.cursor >= len(p.filtered) {
-		return nil
-	}
-
-	cj := p.filtered[p.cursor]
-
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		job, err := p.client.TriggerCronJob(ctx, cj.Namespace, cj.Name)
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-
-		return StatusMsg{Message: fmt.Sprintf("Triggered job: %s", job.Name)}
-	}
-}
-
-func (p *CronJobsPanel) toggleSuspend() tea.Cmd {
-	if p.cursor >= len(p.filtered) {
-		return nil
-	}
-
-	cj := p.filtered[p.cursor]
-
-	currentSuspend := false
-	if cj.Spec.Suspend != nil {
-		currentSuspend = *cj.Spec.Suspend
-	}
-
-	newSuspend := !currentSuspend
-
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		err := p.client.SuspendCronJob(ctx, cj.Namespace, cj.Name, newSuspend)
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-
-		action := "Suspended"
-		if !newSuspend {
-			action = "Resumed"
-		}
-
-		return StatusMsg{Message: fmt.Sprintf("%s cronjob: %s", action, cj.Name)}
 	}
 }
 

--- a/internal/ui/panels/daemonsets.go
+++ b/internal/ui/panels/daemonsets.go
@@ -51,7 +51,18 @@ func (p *DaemonSetsPanel) Update(msg tea.Msg) (Panel, tea.Cmd) {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("G"))):
 			p.MoveToBottom(len(p.filtered))
 		case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
-			return p, p.restartDaemonSet()
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			ds := p.filtered[p.cursor]
+
+			return p, func() tea.Msg {
+				return RestartDaemonSetRequestMsg{
+					DaemonSetName: ds.Name,
+					Namespace:     ds.Namespace,
+				}
+			}
 		}
 
 	case daemonSetsLoadedMsg:
@@ -275,25 +286,6 @@ func (p *DaemonSetsPanel) Delete() tea.Cmd {
 		}
 
 		return StatusMsg{Message: fmt.Sprintf("Deleted daemonset: %s", ds.Name)}
-	}
-}
-
-func (p *DaemonSetsPanel) restartDaemonSet() tea.Cmd {
-	if p.cursor >= len(p.filtered) {
-		return nil
-	}
-
-	ds := p.filtered[p.cursor]
-
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		err := p.client.RestartDaemonSet(ctx, ds.Namespace, ds.Name)
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-
-		return StatusMsg{Message: fmt.Sprintf("Restarted daemonset: %s", ds.Name)}
 	}
 }
 

--- a/internal/ui/panels/deployments.go
+++ b/internal/ui/panels/deployments.go
@@ -70,7 +70,18 @@ func (p *DeploymentsPanel) Update(msg tea.Msg) (Panel, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
-			return p, p.restartDeployment()
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			deploy := p.filtered[p.cursor]
+
+			return p, func() tea.Msg {
+				return RestartDeploymentRequestMsg{
+					DeploymentName: deploy.Name,
+					Namespace:      deploy.Namespace,
+				}
+			}
 		case key.Matches(msg, key.NewBinding(key.WithKeys("R"))):
 			if p.cursor >= len(p.filtered) {
 				return p, nil
@@ -328,25 +339,6 @@ func (p *DeploymentsPanel) Delete() tea.Cmd {
 		}
 
 		return StatusMsg{Message: fmt.Sprintf("Deleted deployment: %s", deploy.Name)}
-	}
-}
-
-func (p *DeploymentsPanel) restartDeployment() tea.Cmd {
-	if p.cursor >= len(p.filtered) {
-		return nil
-	}
-
-	deploy := p.filtered[p.cursor]
-
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		err := p.client.RestartDeployment(ctx, deploy.Namespace, deploy.Name)
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-
-		return StatusMsg{Message: fmt.Sprintf("Restarted deployment: %s", deploy.Name)}
 	}
 }
 

--- a/internal/ui/panels/history_request_msgs_test.go
+++ b/internal/ui/panels/history_request_msgs_test.go
@@ -1,0 +1,307 @@
+package panels
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+func TestDeploymentsPanel_RKeyEmitsRestartRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{testDeployment()}
+	panel.filtered = panel.deployments
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("r key should return a command")
+	}
+
+	result := cmd()
+
+	restartMsg, ok := result.(RestartDeploymentRequestMsg)
+	if !ok {
+		t.Fatalf("expected RestartDeploymentRequestMsg, got %T", result)
+	}
+
+	if restartMsg.DeploymentName != "test-deploy" {
+		t.Errorf(
+			"DeploymentName = %q, want %q",
+			restartMsg.DeploymentName, "test-deploy",
+		)
+	}
+
+	if restartMsg.Namespace != "default" {
+		t.Errorf(
+			"Namespace = %q, want %q",
+			restartMsg.Namespace, "default",
+		)
+	}
+}
+
+func TestDeploymentsPanel_RKeyEmptyList(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDeploymentsPanel(client, styles)
+
+	panel.deployments = []appsv1.Deployment{}
+	panel.filtered = panel.deployments
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("r key with no deployments should return nil cmd")
+	}
+}
+
+func TestStatefulSetsPanel_RKeyEmitsRestartRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewStatefulSetsPanel(client, styles)
+
+	panel.statefulsets = []appsv1.StatefulSet{testStatefulSet()}
+	panel.filtered = panel.statefulsets
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("r key should return a command")
+	}
+
+	result := cmd()
+
+	restartMsg, ok := result.(RestartStatefulSetRequestMsg)
+	if !ok {
+		t.Fatalf("expected RestartStatefulSetRequestMsg, got %T", result)
+	}
+
+	if restartMsg.StatefulSetName != "test-sts" {
+		t.Errorf(
+			"StatefulSetName = %q, want %q",
+			restartMsg.StatefulSetName, "test-sts",
+		)
+	}
+}
+
+func TestStatefulSetsPanel_RKeyEmptyList(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewStatefulSetsPanel(client, styles)
+
+	panel.statefulsets = []appsv1.StatefulSet{}
+	panel.filtered = panel.statefulsets
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("r key with no statefulsets should return nil cmd")
+	}
+}
+
+func TestDaemonSetsPanel_RKeyEmitsRestartRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDaemonSetsPanel(client, styles)
+
+	panel.daemonsets = []appsv1.DaemonSet{testDaemonSet()}
+	panel.filtered = panel.daemonsets
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("r key should return a command")
+	}
+
+	result := cmd()
+
+	restartMsg, ok := result.(RestartDaemonSetRequestMsg)
+	if !ok {
+		t.Fatalf("expected RestartDaemonSetRequestMsg, got %T", result)
+	}
+
+	if restartMsg.DaemonSetName != "test-ds" {
+		t.Errorf(
+			"DaemonSetName = %q, want %q",
+			restartMsg.DaemonSetName, "test-ds",
+		)
+	}
+}
+
+func TestDaemonSetsPanel_RKeyEmptyList(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewDaemonSetsPanel(client, styles)
+
+	panel.daemonsets = []appsv1.DaemonSet{}
+	panel.filtered = panel.daemonsets
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("r key with no daemonsets should return nil cmd")
+	}
+}
+
+func TestCronJobsPanel_SKeyEmitsToggleSuspendRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewCronJobsPanel(client, styles)
+
+	panel.cronjobs = []batchv1.CronJob{testCronJob()}
+	panel.filtered = panel.cronjobs
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("S key should return a command")
+	}
+
+	result := cmd()
+
+	suspendMsg, ok := result.(ToggleSuspendCronJobRequestMsg)
+	if !ok {
+		t.Fatalf(
+			"expected ToggleSuspendCronJobRequestMsg, got %T",
+			result,
+		)
+	}
+
+	if suspendMsg.CronJobName != "test-cronjob" {
+		t.Errorf(
+			"CronJobName = %q, want %q",
+			suspendMsg.CronJobName, "test-cronjob",
+		)
+	}
+
+	if suspendMsg.CurrentSuspend {
+		t.Error("expected CurrentSuspend = false for active cronjob")
+	}
+}
+
+func TestCronJobsPanel_SKeyEmptyList(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewCronJobsPanel(client, styles)
+
+	panel.cronjobs = []batchv1.CronJob{}
+	panel.filtered = panel.cronjobs
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("S key with no cronjobs should return nil cmd")
+	}
+}
+
+func TestCronJobsPanel_TKeyEmitsTriggerRequest(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewCronJobsPanel(client, styles)
+
+	panel.cronjobs = []batchv1.CronJob{testCronJob()}
+	panel.filtered = panel.cronjobs
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("t key should return a command")
+	}
+
+	result := cmd()
+
+	triggerMsg, ok := result.(TriggerCronJobRequestMsg)
+	if !ok {
+		t.Fatalf(
+			"expected TriggerCronJobRequestMsg, got %T",
+			result,
+		)
+	}
+
+	if triggerMsg.CronJobName != "test-cronjob" {
+		t.Errorf(
+			"CronJobName = %q, want %q",
+			triggerMsg.CronJobName, "test-cronjob",
+		)
+	}
+}
+
+func TestCronJobsPanel_TKeyEmptyList(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewCronJobsPanel(client, styles)
+
+	panel.cronjobs = []batchv1.CronJob{}
+	panel.filtered = panel.cronjobs
+	panel.cursor = 0
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd != nil {
+		t.Error("t key with no cronjobs should return nil cmd")
+	}
+}
+
+func TestCronJobsPanel_SKeySuspendedCronJob(t *testing.T) {
+	client := createTestK8sClient()
+	styles := createTestStyles()
+	panel := NewCronJobsPanel(client, styles)
+
+	cj := testCronJob()
+	suspended := true
+	cj.Spec.Suspend = &suspended
+
+	panel.cronjobs = []batchv1.CronJob{cj}
+	panel.filtered = panel.cronjobs
+	panel.cursor = 0
+	panel.SetFocused(true)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}}
+	_, cmd := panel.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("S key should return a command")
+	}
+
+	result := cmd()
+
+	suspendMsg, ok := result.(ToggleSuspendCronJobRequestMsg)
+	if !ok {
+		t.Fatalf(
+			"expected ToggleSuspendCronJobRequestMsg, got %T",
+			result,
+		)
+	}
+
+	if !suspendMsg.CurrentSuspend {
+		t.Error("expected CurrentSuspend = true for suspended cronjob")
+	}
+}

--- a/internal/ui/panels/panel.go
+++ b/internal/ui/panels/panel.go
@@ -74,6 +74,38 @@ type EditHPAMaxReplicasRequestMsg struct {
 	MaxReplicas int32
 }
 
+// RestartDeploymentRequestMsg is emitted by the deployments panel
+// so ui.go can execute the restart and record it in history.
+type RestartDeploymentRequestMsg struct {
+	DeploymentName string
+	Namespace      string
+}
+
+// RestartStatefulSetRequestMsg is emitted by the statefulsets panel.
+type RestartStatefulSetRequestMsg struct {
+	StatefulSetName string
+	Namespace       string
+}
+
+// RestartDaemonSetRequestMsg is emitted by the daemonsets panel.
+type RestartDaemonSetRequestMsg struct {
+	DaemonSetName string
+	Namespace     string
+}
+
+// ToggleSuspendCronJobRequestMsg is emitted by the cronjobs panel.
+type ToggleSuspendCronJobRequestMsg struct {
+	CronJobName    string
+	Namespace      string
+	CurrentSuspend bool
+}
+
+// TriggerCronJobRequestMsg is emitted by the cronjobs panel.
+type TriggerCronJobRequestMsg struct {
+	CronJobName string
+	Namespace   string
+}
+
 type PodMetricsMsg struct {
 	Metrics map[string]PodMetrics
 }

--- a/internal/ui/panels/statefulsets.go
+++ b/internal/ui/panels/statefulsets.go
@@ -70,7 +70,18 @@ func (p *StatefulSetsPanel) Update(msg tea.Msg) (Panel, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
-			return p, p.restartStatefulSet()
+			if p.cursor >= len(p.filtered) {
+				return p, nil
+			}
+
+			sts := p.filtered[p.cursor]
+
+			return p, func() tea.Msg {
+				return RestartStatefulSetRequestMsg{
+					StatefulSetName: sts.Name,
+					Namespace:       sts.Namespace,
+				}
+			}
 		}
 
 	case statefulSetsLoadedMsg:
@@ -298,25 +309,6 @@ func (p *StatefulSetsPanel) Delete() tea.Cmd {
 		}
 
 		return StatusMsg{Message: fmt.Sprintf("Deleted statefulset: %s", sts.Name)}
-	}
-}
-
-func (p *StatefulSetsPanel) restartStatefulSet() tea.Cmd {
-	if p.cursor >= len(p.filtered) {
-		return nil
-	}
-
-	sts := p.filtered[p.cursor]
-
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		err := p.client.RestartStatefulSet(ctx, sts.Namespace, sts.Name)
-		if err != nil {
-			return ErrorMsg{Error: err}
-		}
-
-		return StatusMsg{Message: fmt.Sprintf("Restarted statefulset: %s", sts.Name)}
 	}
 }
 

--- a/internal/ui/theme/keys.go
+++ b/internal/ui/theme/keys.go
@@ -53,6 +53,7 @@ type KeyMap struct {
 	FollowLogs   key.Binding
 	Diff         key.Binding
 	GlobalSearch key.Binding
+	History      key.Binding
 }
 
 func NewKeyMap() *KeyMap {
@@ -204,6 +205,10 @@ func NewKeyMap() *KeyMap {
 			key.WithKeys("ctrl+f"),
 			key.WithHelp("ctrl+f", "global search"),
 		),
+		History: key.NewBinding(
+			key.WithKeys("H"),
+			key.WithHelp("H", "history"),
+		),
 	}
 }
 
@@ -215,7 +220,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right},
 		{k.NextPanel, k.PrevPanel, k.Top, k.Bottom},
-		{k.Enter, k.Back, k.Zoom, k.Search, k.GlobalSearch, k.Refresh},
+		{k.Enter, k.Back, k.Zoom, k.Search, k.GlobalSearch, k.History, k.Refresh},
 		{k.Describe, k.Yaml, k.Logs, k.Exec},
 		{k.Delete, k.Scale, k.Restart, k.PortForward, k.Diff},
 		{k.Context, k.Namespace, k.CopyName, k.Copy},

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -44,6 +44,7 @@ const (
 	ViewContainerSelect
 	ViewDiff
 	ViewGlobalSearch
+	ViewHistory
 )
 
 // borderLines is the number of lines used by panel borders (top + bottom).
@@ -112,6 +113,10 @@ type Model struct {
 
 	// Metrics
 	metricsClient *k8s.MetricsClient
+
+	// Operations history
+	historyStore *components.HistoryStore
+	historyView  *components.HistoryViewer
 }
 
 func NewModel(client *k8s.Client, cfg *config.Config) *Model {
@@ -137,6 +142,8 @@ func NewModel(client *k8s.Client, cfg *config.Config) *Model {
 	m.search = components.NewSearch(styles)
 	m.input = components.NewInput(styles)
 	m.globalSearch = components.NewGlobalSearch(styles)
+	m.historyStore = components.NewHistoryStore()
+	m.historyView = components.NewHistoryViewer(styles, m.historyStore)
 
 	// Initialize metrics client (optional - may fail if metrics-server not installed)
 	metricsClient, err := client.NewMetricsClient()
@@ -308,6 +315,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case ViewGlobalSearch:
 			return m.handleGlobalSearch(msg)
 
+		case ViewHistory:
+			if key.Matches(msg, m.keys.Back) {
+				m.viewMode = ViewNormal
+
+				return m, nil
+			}
+
+			var cmd tea.Cmd
+
+			m.historyView, cmd = m.historyView.Update(msg)
+
+			return m, cmd
+
 		case ViewNormal:
 			// Fall through to normal key handling below
 		}
@@ -356,6 +376,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.globalSearch.Reset()
 			m.globalSearchResults = nil
 			m.viewMode = ViewGlobalSearch
+
+			return m, nil
+
+		case key.Matches(msg, m.keys.History):
+			m.historyView.Reset()
+			m.viewMode = ViewHistory
 
 			return m, nil
 
@@ -534,12 +560,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.DeploymentName,
 			msg.CurrentReplicas,
 		)
+		currentReplicas := msg.CurrentReplicas
+
 		m.showInput(
 			"Scale Deployment",
 			description,
 			strconv.Itoa(int(msg.CurrentReplicas)),
 			func(value string) tea.Cmd {
-				return m.scaleDeployment(msg.Namespace, msg.DeploymentName, value)
+				return m.scaleDeployment(
+					msg.Namespace, msg.DeploymentName,
+					value, currentReplicas,
+				)
 			},
 		)
 		m.input.SetValue(strconv.Itoa(int(msg.CurrentReplicas)))
@@ -618,12 +649,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.StatefulSetName,
 			msg.CurrentReplicas,
 		)
+		currentReplicas := msg.CurrentReplicas
+
 		m.showInput(
 			"Scale StatefulSet",
 			description,
 			strconv.Itoa(int(msg.CurrentReplicas)),
 			func(value string) tea.Cmd {
-				return m.scaleStatefulSet(msg.Namespace, msg.StatefulSetName, value)
+				return m.scaleStatefulSet(
+					msg.Namespace, msg.StatefulSetName,
+					value, currentReplicas,
+				)
 			},
 		)
 		m.input.SetValue(strconv.Itoa(int(msg.CurrentReplicas)))
@@ -636,12 +672,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.HPAName,
 			msg.MinReplicas,
 		)
+		currentMin := msg.MinReplicas
+
 		m.showInput(
 			"Edit HPA Min Replicas",
 			description,
 			strconv.Itoa(int(msg.MinReplicas)),
 			func(value string) tea.Cmd {
-				return m.updateHPAMinReplicas(msg.Namespace, msg.HPAName, value)
+				return m.updateHPAMinReplicas(
+					msg.Namespace, msg.HPAName, value, currentMin,
+				)
 			},
 		)
 		m.input.SetValue(strconv.Itoa(int(msg.MinReplicas)))
@@ -654,17 +694,41 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.HPAName,
 			msg.MaxReplicas,
 		)
+		currentMax := msg.MaxReplicas
+
 		m.showInput(
 			"Edit HPA Max Replicas",
 			description,
 			strconv.Itoa(int(msg.MaxReplicas)),
 			func(value string) tea.Cmd {
-				return m.updateHPAMaxReplicas(msg.Namespace, msg.HPAName, value)
+				return m.updateHPAMaxReplicas(
+					msg.Namespace, msg.HPAName, value, currentMax,
+				)
 			},
 		)
 		m.input.SetValue(strconv.Itoa(int(msg.MaxReplicas)))
 
 		return m, nil
+
+	case panels.RestartDeploymentRequestMsg:
+		return m, m.restartDeployment(msg.Namespace, msg.DeploymentName)
+
+	case panels.RestartStatefulSetRequestMsg:
+		return m, m.restartStatefulSet(msg.Namespace, msg.StatefulSetName)
+
+	case panels.RestartDaemonSetRequestMsg:
+		return m, m.restartDaemonSet(msg.Namespace, msg.DaemonSetName)
+
+	case panels.ToggleSuspendCronJobRequestMsg:
+		return m, m.toggleSuspendCronJob(
+			msg.Namespace, msg.CronJobName, msg.CurrentSuspend,
+		)
+
+	case panels.TriggerCronJobRequestMsg:
+		return m, m.triggerCronJob(msg.Namespace, msg.CronJobName)
+
+	case components.UndoRequestMsg:
+		return m, m.handleUndo(msg.RecordID)
 	}
 
 	// Update ALL panels so they can process their respective loaded messages
@@ -705,6 +769,8 @@ func (m *Model) View() string {
 		content = m.renderSwitchView()
 	case ViewGlobalSearch:
 		content = m.renderGlobalSearchView()
+	case ViewHistory:
+		content = m.historyView.View(m.width, m.height)
 	case ViewInput:
 		content = m.renderNormalView()
 		inputView := m.input.View()
@@ -824,7 +890,7 @@ func (m *Model) renderSwitchView() string {
 	case ViewContainerSelect:
 		title = "Select Container"
 	case ViewNormal, ViewHelp, ViewYaml, ViewLogs, ViewDiff, ViewConfirm, ViewInput,
-		ViewGlobalSearch:
+		ViewGlobalSearch, ViewHistory:
 		// These view modes don't use renderSwitchView
 	}
 
@@ -1261,11 +1327,28 @@ func (m *Model) confirmDelete() (*Model, tea.Cmd) {
 		return m, nil
 	}
 
+	panelTitle := activePanel.Title()
+	ns := m.k8sClient.CurrentNamespace()
+
 	m.confirm.Show(
 		fmt.Sprintf("Delete %s?", name),
-		fmt.Sprintf("Are you sure you want to delete %s? This action cannot be undone.", name),
+		fmt.Sprintf(
+			"Are you sure you want to delete %s? "+
+				"This action cannot be undone.", name,
+		),
 		func() tea.Cmd {
-			return activePanel.Delete()
+			cmd := activePanel.Delete()
+
+			m.historyStore.Add(components.OperationRecord{
+				Type:      components.OpDeleteResource,
+				Resource:  name,
+				Namespace: ns,
+				Message: fmt.Sprintf(
+					"Deleted %s %s", panelTitle, name,
+				),
+			})
+
+			return cmd
 		},
 	)
 	m.viewMode = ViewConfirm
@@ -1299,25 +1382,68 @@ func (m *Model) showInput(title, description, placeholder string, action func(st
 	m.viewMode = ViewInput
 }
 
-func (m *Model) scaleDeployment(namespace, name, replicaStr string) tea.Cmd {
-	return func() tea.Msg {
-		replicas, err := strconv.ParseInt(replicaStr, 10, 32)
-		if err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("invalid replica count: %w", err)}
+// parseReplicaCount parses a replica string and validates it against
+// a minimum value. Returns the parsed count or an error message.
+func parseReplicaCount(
+	replicaStr string,
+	minValue int64,
+	minErr error,
+) (int32, tea.Msg) {
+	replicas, err := strconv.ParseInt(replicaStr, 10, 32)
+	if err != nil {
+		return 0, panels.ErrorMsg{
+			Error: fmt.Errorf("invalid replica count: %w", err),
 		}
+	}
 
-		if replicas < 0 {
-			return panels.ErrorMsg{Error: ErrInvalidReplicaCount}
+	if replicas < minValue {
+		return 0, panels.ErrorMsg{Error: minErr}
+	}
+
+	return int32(replicas), nil
+}
+
+func (m *Model) scaleDeployment(
+	namespace, name, replicaStr string,
+	currentReplicas int32,
+) tea.Cmd {
+	return func() tea.Msg {
+		replicas, errMsg := parseReplicaCount(
+			replicaStr, 0, ErrInvalidReplicaCount,
+		)
+		if errMsg != nil {
+			return errMsg
 		}
 
 		ctx := context.Background()
-		if err := m.k8sClient.ScaleDeployment(ctx, namespace, name, int32(replicas)); err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("failed to scale deployment: %w", err)}
+
+		err := m.k8sClient.ScaleDeployment(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf("failed to scale deployment: %w", err),
+			}
 		}
 
-		// Return status with refresh to show updated pods
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpScaleDeployment,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Scaled %s from %d to %d replicas",
+				name, currentReplicas, replicas,
+			),
+			Undoable: true,
+			UndoData: components.UndoData{
+				PreviousReplicas: currentReplicas,
+			},
+		})
+
 		return panels.StatusWithRefreshMsg{
-			Message: fmt.Sprintf("Scaled %s to %d replicas", name, replicas),
+			Message: fmt.Sprintf(
+				"Scaled %s to %d replicas", name, replicas,
+			),
 		}
 	}
 }
@@ -1326,8 +1452,19 @@ func (m *Model) rollbackDeployment(namespace, name string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		if err := m.k8sClient.RollbackDeployment(ctx, namespace, name); err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("failed to rollback deployment: %w", err)}
+			return panels.ErrorMsg{
+				Error: fmt.Errorf("failed to rollback deployment: %w", err),
+			}
 		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpRollbackDeployment,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Rolled back %s to previous revision", name,
+			),
+		})
 
 		return panels.StatusWithRefreshMsg{
 			Message: fmt.Sprintf("Rolled back %s to previous revision", name),
@@ -1389,76 +1526,143 @@ func (m *Model) loadRevisionDiff(namespace, name string) tea.Cmd {
 	}
 }
 
-func (m *Model) scaleStatefulSet(namespace, name, replicaStr string) tea.Cmd {
+func (m *Model) scaleStatefulSet(
+	namespace, name, replicaStr string,
+	currentReplicas int32,
+) tea.Cmd {
 	return func() tea.Msg {
-		replicas, err := strconv.ParseInt(replicaStr, 10, 32)
-		if err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("invalid replica count: %w", err)}
-		}
-
-		if replicas < 0 {
-			return panels.ErrorMsg{Error: ErrInvalidReplicaCount}
+		replicas, errMsg := parseReplicaCount(
+			replicaStr, 0, ErrInvalidReplicaCount,
+		)
+		if errMsg != nil {
+			return errMsg
 		}
 
 		ctx := context.Background()
-		if err := m.k8sClient.ScaleStatefulSet(ctx, namespace, name, int32(replicas)); err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("failed to scale statefulset: %w", err)}
+
+		err := m.k8sClient.ScaleStatefulSet(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to scale statefulset: %w", err,
+				),
+			}
 		}
 
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpScaleStatefulSet,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Scaled %s from %d to %d replicas",
+				name, currentReplicas, replicas,
+			),
+			Undoable: true,
+			UndoData: components.UndoData{
+				PreviousReplicas: currentReplicas,
+			},
+		})
+
 		return panels.StatusWithRefreshMsg{
-			Message: fmt.Sprintf("Scaled %s to %d replicas", name, replicas),
+			Message: fmt.Sprintf(
+				"Scaled %s to %d replicas", name, replicas,
+			),
 		}
 	}
 }
 
-func (m *Model) updateHPAMinReplicas(namespace, name, replicaStr string) tea.Cmd {
+func (m *Model) updateHPAMinReplicas(
+	namespace, name, replicaStr string,
+	currentMin int32,
+) tea.Cmd {
 	return func() tea.Msg {
-		replicas, err := strconv.ParseInt(replicaStr, 10, 32)
-		if err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("invalid replica count: %w", err)}
-		}
-
-		if replicas < 1 {
-			return panels.ErrorMsg{Error: ErrMinReplicasTooLow}
+		replicas, errMsg := parseReplicaCount(
+			replicaStr, 1, ErrMinReplicasTooLow,
+		)
+		if errMsg != nil {
+			return errMsg
 		}
 
 		ctx := context.Background()
 
-		err = m.k8sClient.UpdateHPAMinReplicas(ctx, namespace, name, int32(replicas))
+		err := m.k8sClient.UpdateHPAMinReplicas(
+			ctx, namespace, name, replicas,
+		)
 		if err != nil {
 			return panels.ErrorMsg{
-				Error: fmt.Errorf("failed to update HPA min replicas: %w", err),
+				Error: fmt.Errorf(
+					"failed to update HPA min replicas: %w", err,
+				),
 			}
 		}
 
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpEditHPAMin,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Updated %s min replicas from %d to %d",
+				name, currentMin, replicas,
+			),
+			Undoable: true,
+			UndoData: components.UndoData{
+				PreviousMinReplicas: currentMin,
+			},
+		})
+
 		return panels.StatusWithRefreshMsg{
-			Message: fmt.Sprintf("Updated %s min replicas to %d", name, replicas),
+			Message: fmt.Sprintf(
+				"Updated %s min replicas to %d", name, replicas,
+			),
 		}
 	}
 }
 
-func (m *Model) updateHPAMaxReplicas(namespace, name, replicaStr string) tea.Cmd {
+func (m *Model) updateHPAMaxReplicas(
+	namespace, name, replicaStr string,
+	currentMax int32,
+) tea.Cmd {
 	return func() tea.Msg {
-		replicas, err := strconv.ParseInt(replicaStr, 10, 32)
-		if err != nil {
-			return panels.ErrorMsg{Error: fmt.Errorf("invalid replica count: %w", err)}
-		}
-
-		if replicas < 1 {
-			return panels.ErrorMsg{Error: ErrMaxReplicasTooLow}
+		replicas, errMsg := parseReplicaCount(
+			replicaStr, 1, ErrMaxReplicasTooLow,
+		)
+		if errMsg != nil {
+			return errMsg
 		}
 
 		ctx := context.Background()
 
-		err = m.k8sClient.UpdateHPAMaxReplicas(ctx, namespace, name, int32(replicas))
+		err := m.k8sClient.UpdateHPAMaxReplicas(
+			ctx, namespace, name, replicas,
+		)
 		if err != nil {
 			return panels.ErrorMsg{
-				Error: fmt.Errorf("failed to update HPA max replicas: %w", err),
+				Error: fmt.Errorf(
+					"failed to update HPA max replicas: %w", err,
+				),
 			}
 		}
 
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpEditHPAMax,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Updated %s max replicas from %d to %d",
+				name, currentMax, replicas,
+			),
+			Undoable: true,
+			UndoData: components.UndoData{
+				PreviousMaxReplicas: currentMax,
+			},
+		})
+
 		return panels.StatusWithRefreshMsg{
-			Message: fmt.Sprintf("Updated %s max replicas to %d", name, replicas),
+			Message: fmt.Sprintf(
+				"Updated %s max replicas to %d", name, replicas,
+			),
 		}
 	}
 }
@@ -1503,8 +1707,21 @@ func (m *Model) startPortForward(namespace, podName, portSpec string) tea.Cmd {
 		key := fmt.Sprintf("%s/%s:%d", namespace, podName, remotePort)
 		m.portForwards[key] = pf
 
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpPortForward,
+			Resource:  podName,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Port forwarding %d -> %s:%d",
+				localPort, podName, remotePort,
+			),
+		})
+
 		return panels.StatusMsg{
-			Message: fmt.Sprintf("Port forwarding %d -> %s:%d", localPort, podName, remotePort),
+			Message: fmt.Sprintf(
+				"Port forwarding %d -> %s:%d",
+				localPort, podName, remotePort,
+			),
 		}
 	}
 }
@@ -1583,6 +1800,15 @@ func (m *Model) handleContainerSelect(msg tea.KeyMsg) (*Model, tea.Cmd) {
 }
 
 func (m *Model) execIntoPod(namespace, podName, container string) tea.Cmd {
+	m.historyStore.Add(components.OperationRecord{
+		Type:      components.OpExec,
+		Resource:  podName,
+		Namespace: namespace,
+		Message: fmt.Sprintf(
+			"Exec into %s (container: %s)", podName, container,
+		),
+	})
+
 	args := []string{
 		"exec", "-it",
 		"-n", namespace,
@@ -1592,20 +1818,22 @@ func (m *Model) execIntoPod(namespace, podName, container string) tea.Cmd {
 		"if command -v bash > /dev/null; then exec bash; else exec sh; fi",
 	}
 
-	c := tea.ExecProcess(
+	return tea.ExecProcess(
 		newKubectlCmd(args...),
 		func(err error) tea.Msg {
 			if err != nil {
-				return panels.ErrorMsg{Error: fmt.Errorf("exec failed: %w", err)}
+				return panels.ErrorMsg{
+					Error: fmt.Errorf("exec failed: %w", err),
+				}
 			}
 
 			return panels.StatusMsg{
-				Message: fmt.Sprintf("Exited shell in %s/%s", podName, container),
+				Message: fmt.Sprintf(
+					"Exited shell in %s/%s", podName, container,
+				),
 			}
 		},
 	)
-
-	return c
 }
 
 func (m *Model) copyNameToClipboard() (*Model, tea.Cmd) {
@@ -1738,6 +1966,17 @@ func (m *Model) editResource() (*Model, tea.Cmd) {
 			}
 		}
 
+		ns := m.k8sClient.CurrentNamespace()
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpEditResource,
+			Resource:  name,
+			Namespace: ns,
+			Message: fmt.Sprintf(
+				"Edited and applied changes to %s", name,
+			),
+		})
+
 		return panels.StatusWithRefreshMsg{
 			Message: fmt.Sprintf("Applied changes to %s", name),
 		}
@@ -1746,6 +1985,311 @@ func (m *Model) editResource() (*Model, tea.Cmd) {
 
 func newKubectlCmd(args ...string) *exec.Cmd {
 	return exec.Command("kubectl", args...) //nolint:noctx
+}
+
+func (m *Model) restartDeployment(namespace, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.RestartDeployment(ctx, namespace, name)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to restart deployment: %w", err,
+				),
+			}
+		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpRestartDeployment,
+			Resource:  name,
+			Namespace: namespace,
+			Message:   fmt.Sprintf("Restarted deployment %s", name),
+		})
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf("Restarted deployment: %s", name),
+		}
+	}
+}
+
+func (m *Model) restartStatefulSet(namespace, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.RestartStatefulSet(ctx, namespace, name)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to restart statefulset: %w", err,
+				),
+			}
+		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpRestartStatefulSet,
+			Resource:  name,
+			Namespace: namespace,
+			Message:   fmt.Sprintf("Restarted statefulset %s", name),
+		})
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf("Restarted statefulset: %s", name),
+		}
+	}
+}
+
+func (m *Model) restartDaemonSet(namespace, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.RestartDaemonSet(ctx, namespace, name)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to restart daemonset: %w", err,
+				),
+			}
+		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpRestartDaemonSet,
+			Resource:  name,
+			Namespace: namespace,
+			Message:   fmt.Sprintf("Restarted daemonset %s", name),
+		})
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf("Restarted daemonset: %s", name),
+		}
+	}
+}
+
+func (m *Model) toggleSuspendCronJob(
+	namespace, name string,
+	currentSuspend bool,
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		newSuspend := !currentSuspend
+
+		err := m.k8sClient.SuspendCronJob(
+			ctx, namespace, name, newSuspend,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to toggle suspend cronjob: %w", err,
+				),
+			}
+		}
+
+		opType := components.OpSuspendCronJob
+		action := "Suspended"
+
+		if !newSuspend {
+			opType = components.OpResumeCronJob
+			action = "Resumed"
+		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      opType,
+			Resource:  name,
+			Namespace: namespace,
+			Message:   fmt.Sprintf("%s cronjob %s", action, name),
+			Undoable:  true,
+			UndoData: components.UndoData{
+				PreviousSuspend: currentSuspend,
+			},
+		})
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf("%s cronjob: %s", action, name),
+		}
+	}
+}
+
+func (m *Model) triggerCronJob(namespace, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		job, err := m.k8sClient.TriggerCronJob(ctx, namespace, name)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"failed to trigger cronjob: %w", err,
+				),
+			}
+		}
+
+		m.historyStore.Add(components.OperationRecord{
+			Type:      components.OpTriggerCronJob,
+			Resource:  name,
+			Namespace: namespace,
+			Message: fmt.Sprintf(
+				"Triggered cronjob %s (job: %s)", name, job.Name,
+			),
+		})
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf("Triggered job: %s", job.Name),
+		}
+	}
+}
+
+// handleUndo reverses a previously recorded operation when possible.
+func (m *Model) handleUndo(recordID int) tea.Cmd {
+	rec, ok := m.historyStore.Get(recordID)
+	if !ok || !rec.Undoable || rec.Undone {
+		return nil
+	}
+
+	m.historyStore.MarkUndone(recordID)
+
+	switch rec.Type {
+	case components.OpScaleDeployment:
+		return m.undoScaleDeployment(
+			rec.Namespace, rec.Resource,
+			rec.UndoData.PreviousReplicas,
+		)
+	case components.OpScaleStatefulSet:
+		return m.undoScaleStatefulSet(
+			rec.Namespace, rec.Resource,
+			rec.UndoData.PreviousReplicas,
+		)
+	case components.OpSuspendCronJob, components.OpResumeCronJob:
+		return m.toggleSuspendCronJob(
+			rec.Namespace, rec.Resource,
+			!rec.UndoData.PreviousSuspend,
+		)
+	case components.OpEditHPAMin:
+		return m.undoHPAMinReplicas(
+			rec.Namespace, rec.Resource,
+			rec.UndoData.PreviousMinReplicas,
+		)
+	case components.OpEditHPAMax:
+		return m.undoHPAMaxReplicas(
+			rec.Namespace, rec.Resource,
+			rec.UndoData.PreviousMaxReplicas,
+		)
+	case components.OpRestartDeployment,
+		components.OpRestartStatefulSet,
+		components.OpRestartDaemonSet,
+		components.OpRollbackDeployment,
+		components.OpDeleteResource,
+		components.OpPortForward,
+		components.OpExec,
+		components.OpEditResource,
+		components.OpTriggerCronJob:
+		// These operations are not reversible
+		return nil
+	}
+
+	return nil
+}
+
+func (m *Model) undoScaleDeployment(
+	namespace, name string,
+	replicas int32,
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.ScaleDeployment(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf("undo scale failed: %w", err),
+			}
+		}
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf(
+				"Undone: restored %s to %d replicas",
+				name, replicas,
+			),
+		}
+	}
+}
+
+func (m *Model) undoScaleStatefulSet(
+	namespace, name string,
+	replicas int32,
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.ScaleStatefulSet(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf("undo scale failed: %w", err),
+			}
+		}
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf(
+				"Undone: restored %s to %d replicas",
+				name, replicas,
+			),
+		}
+	}
+}
+
+func (m *Model) undoHPAMinReplicas(
+	namespace, name string,
+	replicas int32,
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.UpdateHPAMinReplicas(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"undo HPA min replicas failed: %w", err,
+				),
+			}
+		}
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf(
+				"Undone: restored %s min replicas to %d",
+				name, replicas,
+			),
+		}
+	}
+}
+
+func (m *Model) undoHPAMaxReplicas(
+	namespace, name string,
+	replicas int32,
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		err := m.k8sClient.UpdateHPAMaxReplicas(
+			ctx, namespace, name, replicas,
+		)
+		if err != nil {
+			return panels.ErrorMsg{
+				Error: fmt.Errorf(
+					"undo HPA max replicas failed: %w", err,
+				),
+			}
+		}
+
+		return panels.StatusWithRefreshMsg{
+			Message: fmt.Sprintf(
+				"Undone: restored %s max replicas to %d",
+				name, replicas,
+			),
+		}
+	}
 }
 
 func (m *Model) metricsTickCmd() tea.Cmd {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1134,6 +1134,8 @@ func createTestModel() *Model {
 	podsPanel := panels.NewPodsPanel(client, styles)
 	deploysPanel := panels.NewDeploymentsPanel(client, styles)
 
+	historyStore := components.NewHistoryStore()
+
 	return &Model{
 		styles:       styles,
 		keys:         keys,
@@ -1141,7 +1143,10 @@ func createTestModel() *Model {
 		viewMode:     ViewNormal,
 		diffView:     components.NewDiffViewer(styles),
 		globalSearch: components.NewGlobalSearch(styles),
+		historyStore: historyStore,
+		historyView:  components.NewHistoryViewer(styles, historyStore),
 		panels:       []panels.Panel{podsPanel, deploysPanel},
+		portForwards: make(map[string]*k8s.PortForwarder),
 		width:        100,
 		height:       30,
 	}
@@ -1618,5 +1623,537 @@ func TestRenderGlobalSearchGroupHeaders(t *testing.T) {
 
 	if !strings.Contains(output, "Deployments (1)") {
 		t.Error("expected group header 'Deployments (1)'")
+	}
+}
+
+// TestViewModeHistory verifies ViewHistory constant.
+func TestViewModeHistory(t *testing.T) {
+	if int(ViewHistory) != 11 {
+		t.Errorf("ViewHistory = %d, want 11", int(ViewHistory))
+	}
+}
+
+// TestHistoryKeyOpensHistoryView tests that pressing H opens history.
+func TestHistoryKeyOpensHistoryView(t *testing.T) {
+	m := createTestModel()
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}}
+	result, _ := m.Update(msg)
+
+	updated, ok := result.(*Model)
+	if !ok {
+		t.Fatal("Update should return *Model")
+	}
+
+	if updated.viewMode != ViewHistory {
+		t.Errorf(
+			"viewMode = %d, want %d (ViewHistory)",
+			updated.viewMode, ViewHistory,
+		)
+	}
+}
+
+// TestHistoryEscReturnsToNormal tests that Esc closes history.
+func TestHistoryEscReturnsToNormal(t *testing.T) {
+	m := createTestModel()
+	m.viewMode = ViewHistory
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	result, _ := m.Update(msg)
+
+	updated, ok := result.(*Model)
+	if !ok {
+		t.Fatal("Update should return *Model")
+	}
+
+	if updated.viewMode != ViewNormal {
+		t.Errorf(
+			"viewMode = %d, want %d (ViewNormal)",
+			updated.viewMode, ViewNormal,
+		)
+	}
+}
+
+// TestHistoryViewRendering tests that ViewHistory renders correctly.
+func TestHistoryViewRendering(t *testing.T) {
+	m := createTestModel()
+	m.viewMode = ViewHistory
+
+	output := m.View()
+
+	if !strings.Contains(output, "Operations History") {
+		t.Error("expected 'Operations History' title in output")
+	}
+}
+
+// TestScaleDeploymentRecordsHistory tests that scaling errors
+// don't record history. The fake clientset doesn't support GetScale
+// subresource, so we verify the error path.
+func TestScaleDeploymentRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	// Fake clientset doesn't support GetScale, so this will error
+	cmd := m.scaleDeployment("default", "nginx", "5", 3)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg from fake client, got %T", result)
+	}
+
+	if m.historyStore.Len() != 0 {
+		t.Error("history should not be recorded on error")
+	}
+}
+
+// TestScaleDeploymentInvalidInput tests error on bad input.
+func TestScaleDeploymentInvalidInput(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.scaleDeployment("default", "nginx", "abc", 3)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg, got %T", result)
+	}
+
+	if m.historyStore.Len() != 0 {
+		t.Error("history should not be recorded on error")
+	}
+}
+
+// TestScaleDeploymentNegativeInput tests error on negative input.
+func TestScaleDeploymentNegativeInput(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.scaleDeployment("default", "nginx", "-1", 3)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg, got %T", result)
+	}
+}
+
+// TestScaleStatefulSetRecordsHistory tests that scaling errors
+// don't record history.
+func TestScaleStatefulSetRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.scaleStatefulSet("default", "redis", "3", 1)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg from fake client, got %T", result)
+	}
+
+	if m.historyStore.Len() != 0 {
+		t.Error("history should not be recorded on error")
+	}
+}
+
+// TestRollbackDeploymentRecordsHistory tests rollback recording.
+func TestRollbackDeploymentRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.rollbackDeployment("default", "nginx")
+	result := cmd()
+
+	// Rollback will fail on fake client (no revisions), but let's
+	// test that errors don't record history.
+	switch result.(type) {
+	case panels.ErrorMsg:
+		if m.historyStore.Len() != 0 {
+			t.Error("history should not be recorded on error")
+		}
+	case panels.StatusWithRefreshMsg:
+		if m.historyStore.Len() != 1 {
+			t.Error("expected 1 history record on success")
+		}
+	default:
+		t.Fatalf("unexpected msg type %T", result)
+	}
+}
+
+// TestRestartDeploymentRecordsHistory tests restart recording.
+func TestRestartDeploymentRecordsHistory(t *testing.T) {
+	fakeClientset := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx",
+				Namespace: "default",
+			},
+		},
+	)
+	client := k8s.NewTestClient(fakeClientset)
+	m := createTestModel()
+	m.k8sClient = client
+
+	cmd := m.restartDeployment("default", "nginx")
+	result := cmd()
+
+	_, ok := result.(panels.StatusWithRefreshMsg)
+	if !ok {
+		t.Fatalf("expected StatusWithRefreshMsg, got %T", result)
+	}
+
+	if m.historyStore.Len() != 1 {
+		t.Fatalf("expected 1 history record, got %d", m.historyStore.Len())
+	}
+
+	rec, _ := m.historyStore.Get(0)
+	if rec.Type != components.OpRestartDeployment {
+		t.Errorf("expected OpRestartDeployment, got %d", rec.Type)
+	}
+
+	if rec.Undoable {
+		t.Error("restart should not be undoable")
+	}
+}
+
+// TestRestartStatefulSetRecordsHistory tests statefulset restart.
+func TestRestartStatefulSetRecordsHistory(t *testing.T) {
+	fakeClientset := fake.NewSimpleClientset(
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "redis",
+				Namespace: "default",
+			},
+		},
+	)
+	client := k8s.NewTestClient(fakeClientset)
+	m := createTestModel()
+	m.k8sClient = client
+
+	cmd := m.restartStatefulSet("default", "redis")
+	result := cmd()
+
+	_, ok := result.(panels.StatusWithRefreshMsg)
+	if !ok {
+		t.Fatalf("expected StatusWithRefreshMsg, got %T", result)
+	}
+
+	if m.historyStore.Len() != 1 {
+		t.Fatalf("expected 1 history record, got %d", m.historyStore.Len())
+	}
+}
+
+// TestRestartDaemonSetRecordsHistory tests daemonset restart.
+func TestRestartDaemonSetRecordsHistory(t *testing.T) {
+	fakeClientset := fake.NewSimpleClientset(
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fluentd",
+				Namespace: "default",
+			},
+		},
+	)
+	client := k8s.NewTestClient(fakeClientset)
+	m := createTestModel()
+	m.k8sClient = client
+
+	cmd := m.restartDaemonSet("default", "fluentd")
+	result := cmd()
+
+	_, ok := result.(panels.StatusWithRefreshMsg)
+	if !ok {
+		t.Fatalf("expected StatusWithRefreshMsg, got %T", result)
+	}
+
+	if m.historyStore.Len() != 1 {
+		t.Fatalf("expected 1 history record, got %d", m.historyStore.Len())
+	}
+
+	rec, _ := m.historyStore.Get(0)
+	if rec.Type != components.OpRestartDaemonSet {
+		t.Errorf("expected OpRestartDaemonSet, got %d", rec.Type)
+	}
+}
+
+// TestToggleSuspendCronJobRecordsHistory tests suspend toggle.
+func TestToggleSuspendCronJobRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.toggleSuspendCronJob("default", "cleanup", false)
+	result := cmd()
+
+	// Will fail on fake client without the cronjob, but test the error path.
+	switch result.(type) {
+	case panels.ErrorMsg:
+		if m.historyStore.Len() != 0 {
+			t.Error("history should not be recorded on error")
+		}
+	case panels.StatusWithRefreshMsg:
+		if m.historyStore.Len() != 1 {
+			t.Error("expected 1 history record on success")
+		}
+	default:
+		t.Fatalf("unexpected msg type %T", result)
+	}
+}
+
+// TestUpdateHPAMinReplicasRecordsHistory tests HPA min update.
+func TestUpdateHPAMinReplicasRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.updateHPAMinReplicas("default", "web-hpa", "2", 1)
+	result := cmd()
+
+	// Will fail on fake client, but test error path.
+	switch result.(type) {
+	case panels.ErrorMsg:
+		if m.historyStore.Len() != 0 {
+			t.Error("history should not be recorded on error")
+		}
+	case panels.StatusWithRefreshMsg:
+		if m.historyStore.Len() != 1 {
+			t.Error("expected 1 history record on success")
+		}
+	default:
+		t.Fatalf("unexpected msg type %T", result)
+	}
+}
+
+// TestUpdateHPAMinReplicasInvalidInput tests error on bad input.
+func TestUpdateHPAMinReplicasInvalidInput(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.updateHPAMinReplicas("default", "hpa", "0", 1)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg for 0 min replicas, got %T", result)
+	}
+}
+
+// TestUpdateHPAMaxReplicasInvalidInput tests error on bad input.
+func TestUpdateHPAMaxReplicasInvalidInput(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.updateHPAMaxReplicas("default", "hpa", "0", 5)
+	result := cmd()
+
+	_, ok := result.(panels.ErrorMsg)
+	if !ok {
+		t.Fatalf("expected ErrorMsg for 0 max replicas, got %T", result)
+	}
+}
+
+// TestParseReplicaCount tests the helper function.
+func TestParseReplicaCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		min     int64
+		wantErr bool
+		want    int32
+	}{
+		{"valid", "5", 0, false, 5},
+		{"zero allowed", "0", 0, false, 0},
+		{"below min", "0", 1, true, 0},
+		{"negative", "-1", 0, true, 0},
+		{"invalid string", "abc", 0, true, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, errMsg := parseReplicaCount(
+				tt.input, tt.min, ErrInvalidReplicaCount,
+			)
+			if tt.wantErr {
+				if errMsg == nil {
+					t.Error("expected error message")
+				}
+			} else {
+				if errMsg != nil {
+					t.Errorf("unexpected error: %v", errMsg)
+				}
+
+				if got != tt.want {
+					t.Errorf("got %d, want %d", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUndoScaleDeployment tests the undo flow.
+func TestHandleUndoScaleDeployment(t *testing.T) {
+	m := createTestModel()
+
+	// Add a history entry directly
+	m.historyStore.Add(components.OperationRecord{
+		Type:      components.OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Undoable:  true,
+		UndoData: components.UndoData{
+			PreviousReplicas: 3,
+		},
+	})
+
+	// Undo returns a command (it will fail on fake client, but
+	// the record should still be marked undone)
+	undoCmd := m.handleUndo(0)
+	if undoCmd == nil {
+		t.Fatal("expected undo command")
+	}
+
+	rec, _ := m.historyStore.Get(0)
+	if !rec.Undone {
+		t.Error("expected record to be marked as undone")
+	}
+}
+
+// TestHandleUndoInvalidID tests undo with invalid record ID.
+func TestHandleUndoInvalidID(t *testing.T) {
+	m := createTestModel()
+
+	cmd := m.handleUndo(999)
+	if cmd != nil {
+		t.Error("expected nil cmd for invalid record ID")
+	}
+}
+
+// TestHandleUndoNonUndoable tests undo on non-undoable record.
+func TestHandleUndoNonUndoable(t *testing.T) {
+	m := createTestModel()
+
+	m.historyStore.Add(components.OperationRecord{
+		Type:     components.OpDeleteResource,
+		Resource: "pod",
+		Undoable: false,
+	})
+
+	cmd := m.handleUndo(0)
+	if cmd != nil {
+		t.Error("expected nil cmd for non-undoable record")
+	}
+}
+
+// TestHandleUndoAlreadyUndone tests undo on already-undone record.
+func TestHandleUndoAlreadyUndone(t *testing.T) {
+	m := createTestModel()
+
+	id := m.historyStore.Add(components.OperationRecord{
+		Type:     components.OpScaleDeployment,
+		Resource: "nginx",
+		Undoable: true,
+	})
+
+	m.historyStore.MarkUndone(id)
+
+	cmd := m.handleUndo(id)
+	if cmd != nil {
+		t.Error("expected nil cmd for already-undone record")
+	}
+}
+
+// TestRestartRequestMsgHandling tests that restart msgs are handled.
+func TestRestartRequestMsgHandling(t *testing.T) {
+	fakeClientset := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx",
+				Namespace: "default",
+			},
+		},
+	)
+	client := k8s.NewTestClient(fakeClientset)
+	m := createTestModel()
+	m.k8sClient = client
+
+	msg := panels.RestartDeploymentRequestMsg{
+		DeploymentName: "nginx",
+		Namespace:      "default",
+	}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected command from restart request")
+	}
+
+	result := cmd()
+
+	_, ok := result.(panels.StatusWithRefreshMsg)
+	if !ok {
+		t.Fatalf("expected StatusWithRefreshMsg, got %T", result)
+	}
+}
+
+// TestUndoRequestMsgHandling tests that UndoRequestMsg is handled.
+func TestUndoRequestMsgHandling(t *testing.T) {
+	m := createTestModel()
+
+	// Create a history entry
+	m.historyStore.Add(components.OperationRecord{
+		Type:      components.OpScaleDeployment,
+		Resource:  "nginx",
+		Namespace: "default",
+		Undoable:  true,
+		UndoData: components.UndoData{
+			PreviousReplicas: 3,
+		},
+	})
+
+	msg := components.UndoRequestMsg{RecordID: 0}
+	_, cmd := m.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("expected command from undo request")
+	}
+}
+
+// TestHistoryNavigationInHistoryView tests j/k navigation.
+func TestHistoryNavigationInHistoryView(t *testing.T) {
+	m := createTestModel()
+	m.viewMode = ViewHistory
+
+	m.historyStore.Add(components.OperationRecord{
+		Type: components.OpDeleteResource, Resource: "a",
+	})
+	m.historyStore.Add(components.OperationRecord{
+		Type: components.OpDeleteResource, Resource: "b",
+	})
+
+	// Press j to move down
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}
+	result, _ := m.Update(msg)
+
+	updated, ok := result.(*Model)
+	if !ok {
+		t.Fatal("Update should return *Model")
+	}
+
+	// Should still be in ViewHistory
+	if updated.viewMode != ViewHistory {
+		t.Errorf(
+			"viewMode = %d, want %d (ViewHistory)",
+			updated.viewMode, ViewHistory,
+		)
+	}
+}
+
+// TestExecRecordsHistory tests that exec records history.
+func TestExecRecordsHistory(t *testing.T) {
+	m := createTestModel()
+
+	// execIntoPod records history before launching the process
+	_ = m.execIntoPod("default", "test-pod", "main")
+
+	if m.historyStore.Len() != 1 {
+		t.Fatalf("expected 1 history record, got %d", m.historyStore.Len())
+	}
+
+	rec, _ := m.historyStore.Get(0)
+	if rec.Type != components.OpExec {
+		t.Errorf("expected OpExec, got %d", rec.Type)
+	}
+
+	if rec.Resource != "test-pod" {
+		t.Errorf("expected resource test-pod, got %s", rec.Resource)
 	}
 }


### PR DESCRIPTION
## Summary
- Add in-session operations history viewer (press `H`)
- Log all mutating actions (scale, restart, delete, rollback, exec, port-forward, edit, suspend/resume, trigger)
- Undo support for reversible operations (scale, HPA edit, suspend/resume)

## Test plan
- [x] All existing tests pass
- [x] New unit tests for HistoryStore and HistoryViewer
- [x] Linter passes clean