### PR TITLE
Tail logs from Deployments, StatefulSets, DaemonSets, and Jobs

### DIFF
--- a/internal/k8s/daemonsets.go
+++ b/internal/k8s/daemonsets.go
@@ -80,6 +80,16 @@ func (c *Client) RestartDaemonSet(ctx context.Context, namespace, name string) e
 	return err
 }
 
+// GetDaemonSetPodSelector returns the DaemonSet's pod selector as a string
+// usable with List(ListOptions{LabelSelector: ...}).
+func GetDaemonSetPodSelector(ds *appsv1.DaemonSet) string {
+	if ds.Spec.Selector == nil {
+		return ""
+	}
+
+	return metav1.FormatLabelSelector(ds.Spec.Selector)
+}
+
 func GetDaemonSetReadyCount(ds *appsv1.DaemonSet) string {
 	return fmt.Sprintf("%d/%d", ds.Status.NumberReady, ds.Status.DesiredNumberScheduled)
 }

--- a/internal/k8s/daemonsets_test.go
+++ b/internal/k8s/daemonsets_test.go
@@ -2,13 +2,53 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestGetDaemonSetPodSelector(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "node-agent"},
+			},
+		},
+	}
+
+	got := GetDaemonSetPodSelector(ds)
+	if !strings.Contains(got, "app=node-agent") {
+		t.Errorf("GetDaemonSetPodSelector = %q, want app=node-agent", got)
+	}
+
+	if GetDaemonSetPodSelector(&appsv1.DaemonSet{}) != "" {
+		t.Error("GetDaemonSetPodSelector on empty DaemonSet should return empty string")
+	}
+}
+
+func TestGetJobPodSelector(t *testing.T) {
+	job := &batchv1.Job{
+		Spec: batchv1.JobSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"controller-uid": "abc-123"},
+			},
+		},
+	}
+
+	got := GetJobPodSelector(job)
+	if !strings.Contains(got, "controller-uid=abc-123") {
+		t.Errorf("GetJobPodSelector = %q, want controller-uid=abc-123", got)
+	}
+
+	if GetJobPodSelector(&batchv1.Job{}) != "" {
+		t.Error("GetJobPodSelector on empty Job should return empty string")
+	}
+}
 
 func TestListDaemonSets(t *testing.T) {
 	clientset := fake.NewSimpleClientset(

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -290,6 +290,17 @@ func GetDeploymentReadyCount(deployment *appsv1.Deployment) string {
 	return fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
 }
 
+// GetDeploymentPodSelector renders the deployment's pod label selector as a
+// string usable with List(ListOptions{LabelSelector: ...}). An empty selector
+// means the deployment matches everything in its namespace (rare but valid).
+func GetDeploymentPodSelector(deployment *appsv1.Deployment) string {
+	if deployment.Spec.Selector == nil {
+		return ""
+	}
+
+	return metav1.FormatLabelSelector(deployment.Spec.Selector)
+}
+
 func GetDeploymentImages(deployment *appsv1.Deployment) []string {
 	images := make([]string, 0)
 	for _, container := range deployment.Spec.Template.Spec.Containers {

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -16,6 +16,25 @@ func int32Ptr(i int32) *int32 {
 	return &i
 }
 
+func TestGetDeploymentPodSelector(t *testing.T) {
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo", "tier": "web"},
+			},
+		},
+	}
+
+	got := GetDeploymentPodSelector(d)
+	if !strings.Contains(got, "app=demo") || !strings.Contains(got, "tier=web") {
+		t.Errorf("GetDeploymentPodSelector = %q, want both app=demo and tier=web", got)
+	}
+
+	if GetDeploymentPodSelector(&appsv1.Deployment{}) != "" {
+		t.Error("GetDeploymentPodSelector on empty deployment should return empty string")
+	}
+}
+
 func TestListDeployments(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&appsv1.Deployment{

--- a/internal/k8s/jobs.go
+++ b/internal/k8s/jobs.go
@@ -1,0 +1,18 @@
+package k8s
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetJobPodSelector returns the Job's pod selector as a string usable with
+// List(ListOptions{LabelSelector: ...}). The API server auto-populates
+// Spec.Selector with a controller-uid label, so matching is reliable even for
+// jobs that omit an explicit selector in their manifest.
+func GetJobPodSelector(job *batchv1.Job) string {
+	if job.Spec.Selector == nil {
+		return ""
+	}
+
+	return metav1.FormatLabelSelector(job.Spec.Selector)
+}

--- a/internal/k8s/logs.go
+++ b/internal/k8s/logs.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -111,4 +113,68 @@ func (c *Client) GetPodLogSnapshot(
 	}
 
 	return string(raw), nil
+}
+
+// GetPodsLogSnapshot fetches a log snapshot from every named pod concurrently
+// and returns a single blob where each line is prefixed with "[podName] ".
+// Pods that fail to return logs surface as error lines rather than aborting
+// the whole call — one broken pod shouldn't hide logs from the rest.
+func (c *Client) GetPodsLogSnapshot(
+	ctx context.Context,
+	namespace string,
+	podNames []string,
+	opts LogOptions,
+) (string, error) {
+	if namespace == "" {
+		namespace = c.namespace
+	}
+
+	if len(podNames) == 0 {
+		return "", nil
+	}
+
+	type podResult struct {
+		name    string
+		content string
+		err     error
+	}
+
+	results := make([]podResult, len(podNames))
+
+	var wg sync.WaitGroup
+
+	for i, name := range podNames {
+		wg.Add(1)
+
+		go func(idx int, podName string) {
+			defer wg.Done()
+
+			content, err := c.GetPodLogSnapshot(ctx, namespace, podName, opts)
+			results[idx] = podResult{name: podName, content: content, err: err}
+		}(i, name)
+	}
+
+	wg.Wait()
+
+	var b strings.Builder
+
+	for _, r := range results {
+		if r.err != nil {
+			b.WriteString("[" + r.name + "] <error: " + r.err.Error() + ">\n")
+
+			continue
+		}
+
+		for line := range strings.SplitSeq(r.content, "\n") {
+			if line == "" {
+				continue
+			}
+
+			b.WriteString("[" + r.name + "] ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String(), nil
 }

--- a/internal/k8s/logs_test.go
+++ b/internal/k8s/logs_test.go
@@ -1,0 +1,57 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetPodsLogSnapshotEmpty(t *testing.T) {
+	client := createTestClient(fake.NewSimpleClientset())
+
+	got, err := client.GetPodsLogSnapshot(context.Background(), "default", nil, LogOptions{})
+	if err != nil {
+		t.Fatalf("GetPodsLogSnapshot returned error: %v", err)
+	}
+
+	if got != "" {
+		t.Errorf("GetPodsLogSnapshot with empty pod list = %q, want empty string", got)
+	}
+}
+
+func TestGetPodsLogSnapshotPrefixesLines(t *testing.T) {
+	// fake clientset returns "fake logs" for every GetLogs call; the test
+	// verifies our prefixing wraps that content with the right pod names
+	// rather than the content of the logs themselves.
+	clientset := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"},
+		},
+	)
+	client := createTestClient(clientset)
+
+	got, err := client.GetPodsLogSnapshot(
+		context.Background(),
+		"default",
+		[]string{"pod-a", "pod-b"},
+		LogOptions{TailLines: 10},
+	)
+	if err != nil {
+		t.Fatalf("GetPodsLogSnapshot returned error: %v", err)
+	}
+
+	if !strings.Contains(got, "[pod-a] ") {
+		t.Errorf("GetPodsLogSnapshot missing pod-a prefix: %q", got)
+	}
+
+	if !strings.Contains(got, "[pod-b] ") {
+		t.Errorf("GetPodsLogSnapshot missing pod-b prefix: %q", got)
+	}
+}

--- a/internal/k8s/pods.go
+++ b/internal/k8s/pods.go
@@ -52,6 +52,26 @@ func (c *Client) ListPodsAllNamespaces(ctx context.Context) ([]corev1.Pod, error
 	return list.Items, nil
 }
 
+// ListPodsBySelector returns pods matching the given label selector in a namespace.
+// An empty selector matches every pod in the namespace (server-side behavior).
+func (c *Client) ListPodsBySelector(
+	ctx context.Context,
+	namespace, selector string,
+) ([]corev1.Pod, error) {
+	if namespace == "" {
+		namespace = c.namespace
+	}
+
+	list, err := c.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}
+
 func (c *Client) GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
 	if namespace == "" {
 		namespace = c.namespace

--- a/internal/k8s/pods_test.go
+++ b/internal/k8s/pods_test.go
@@ -75,6 +75,53 @@ func TestListPods(t *testing.T) {
 	}
 }
 
+func TestListPodsBySelector(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "api-1",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "api"},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "api-2",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "api"},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker-1",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "worker"},
+			},
+		},
+	)
+
+	client := createTestClient(clientset)
+	ctx := context.Background()
+
+	pods, err := client.ListPodsBySelector(ctx, "default", "app=api")
+	if err != nil {
+		t.Fatalf("ListPodsBySelector returned error: %v", err)
+	}
+
+	if len(pods) != 2 {
+		t.Errorf("ListPodsBySelector returned %d pods, want 2", len(pods))
+	}
+
+	pods, err = client.ListPodsBySelector(ctx, "default", "app=worker")
+	if err != nil {
+		t.Fatalf("ListPodsBySelector returned error: %v", err)
+	}
+
+	if len(pods) != 1 {
+		t.Errorf("ListPodsBySelector returned %d pods, want 1", len(pods))
+	}
+}
+
 func TestListPodsAllNamespaces(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&corev1.Pod{

--- a/internal/k8s/statefulsets.go
+++ b/internal/k8s/statefulsets.go
@@ -113,6 +113,16 @@ func GetStatefulSetReadyCount(sts *appsv1.StatefulSet) string {
 	return fmt.Sprintf("%d/%d", sts.Status.ReadyReplicas, desired)
 }
 
+// GetStatefulSetPodSelector returns the StatefulSet's pod selector as a string
+// usable with List(ListOptions{LabelSelector: ...}).
+func GetStatefulSetPodSelector(sts *appsv1.StatefulSet) string {
+	if sts.Spec.Selector == nil {
+		return ""
+	}
+
+	return metav1.FormatLabelSelector(sts.Spec.Selector)
+}
+
 func GetStatefulSetImages(sts *appsv1.StatefulSet) []string {
 	images := make([]string, 0)
 	for _, container := range sts.Spec.Template.Spec.Containers {

--- a/internal/k8s/statefulsets_test.go
+++ b/internal/k8s/statefulsets_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -9,6 +10,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestGetStatefulSetPodSelector(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "db"},
+			},
+		},
+	}
+
+	got := GetStatefulSetPodSelector(sts)
+	if !strings.Contains(got, "app=db") {
+		t.Errorf("GetStatefulSetPodSelector = %q, want it to contain app=db", got)
+	}
+
+	if GetStatefulSetPodSelector(&appsv1.StatefulSet{}) != "" {
+		t.Error("GetStatefulSetPodSelector on empty StatefulSet should return empty string")
+	}
+}
 
 func TestListStatefulSets(t *testing.T) {
 	clientset := fake.NewSimpleClientset(

--- a/internal/ui/components/logs.go
+++ b/internal/ui/components/logs.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,15 +20,18 @@ type LogLineMsg struct {
 }
 
 type LogViewer struct {
-	styles       *theme.Styles
-	lines        []string
-	offset       int
-	width        int
-	height       int
-	follow       bool
-	pod          string
-	namespace    string
-	container    string
+	styles    *theme.Styles
+	lines     []string
+	offset    int
+	width     int
+	height    int
+	follow    bool
+	pod       string
+	namespace string
+	container string
+	// title overrides "Logs: <pod>" when streaming from multiple pods
+	// (e.g. "Logs: Deployment/my-app (3 pods)"). Empty in single-pod mode.
+	title        string
 	cancel       context.CancelFunc
 	maxLines     int
 	searchActive bool
@@ -61,6 +65,7 @@ func (l *LogViewer) Start(client *k8s.Client, namespace, pod, container string) 
 	l.pod = pod
 	l.namespace = namespace
 	l.container = container
+	l.title = ""
 	l.lines = make([]string, 0)
 	l.offset = 0
 
@@ -97,6 +102,64 @@ func (l *LogViewer) Start(client *k8s.Client, namespace, pod, container string) 
 
 		return LogLineMsg{Line: logs}
 	}
+}
+
+// StartMulti tails logs from every pod matching selector, prefixing each line
+// with the pod name so multiplexed output is readable. The title reflects the
+// owning workload ("Logs: Deployment/my-app (3 pods)") rather than a pod name.
+//
+// If no pods match the selector, returns a status line instead of silent
+// emptiness — a label typo is the common reason and empty UI hides it.
+func (l *LogViewer) StartMulti(
+	client *k8s.Client,
+	namespace, workloadKind, workloadName, selector string,
+) tea.Cmd {
+	l.pod = ""
+	l.namespace = namespace
+	l.container = ""
+	l.title = "Logs: " + workloadKind + "/" + workloadName
+	l.lines = make([]string, 0)
+	l.offset = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l.cancel = cancel
+
+	return func() tea.Msg {
+		pods, err := client.ListPodsBySelector(ctx, namespace, selector)
+		if err != nil {
+			return LogLineMsg{Error: err}
+		}
+
+		if len(pods) == 0 {
+			return LogLineMsg{Line: "No pods match selector: " + selector + "\n"}
+		}
+
+		names := make([]string, 0, len(pods))
+		for _, p := range pods {
+			names = append(names, p.Name)
+		}
+
+		// Update the header count now that we know how many pods matched.
+		l.title = "Logs: " + workloadKind + "/" + workloadName +
+			" (" + podCountLabel(len(names)) + ")"
+
+		logs, err := client.GetPodsLogSnapshot(ctx, namespace, names, k8s.LogOptions{
+			TailLines: 100,
+		})
+		if err != nil {
+			return LogLineMsg{Error: err}
+		}
+
+		return LogLineMsg{Line: logs}
+	}
+}
+
+func podCountLabel(n int) string {
+	if n == 1 {
+		return "1 pod"
+	}
+
+	return strconv.Itoa(n) + " pods"
 }
 
 func (l *LogViewer) Stop() {
@@ -288,7 +351,12 @@ func (l *LogViewer) View(width, height int) string {
 
 	var b strings.Builder
 
-	title := l.styles.ModalTitle.Render("Logs: " + l.pod)
+	titleText := l.title
+	if titleText == "" {
+		titleText = "Logs: " + l.pod
+	}
+
+	title := l.styles.ModalTitle.Render(titleText)
 
 	followIndicator := ""
 	if l.follow {

--- a/internal/ui/components/logs_test.go
+++ b/internal/ui/components/logs_test.go
@@ -483,3 +483,42 @@ type testError struct{}
 func (e *testError) Error() string {
 	return "test error"
 }
+
+func TestPodCountLabel(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{1, "1 pod"},
+		{0, "0 pods"},
+		{3, "3 pods"},
+		{42, "42 pods"},
+	}
+
+	for _, tt := range tests {
+		if got := podCountLabel(tt.n); got != tt.want {
+			t.Errorf("podCountLabel(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+// TestLogViewerViewUsesMultiTitle verifies that when title is set (multi-pod
+// mode) the rendered view uses it rather than the single pod-name fallback.
+func TestLogViewerViewUsesMultiTitle(t *testing.T) {
+	styles := createTestStyles()
+	viewer := NewLogViewer(styles)
+
+	viewer.pod = "should-not-appear"
+	viewer.title = "Logs: Deployment/my-app (3 pods)"
+	viewer.lines = []string{"log line"}
+
+	view := viewer.View(120, 20)
+
+	if !strings.Contains(view, "Deployment/my-app") {
+		t.Errorf("expected multi-pod title in view, got:\n%s", view)
+	}
+
+	if strings.Contains(view, "should-not-appear") {
+		t.Error("single-pod fallback rendered despite title being set")
+	}
+}

--- a/internal/ui/integration_test.go
+++ b/internal/ui/integration_test.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/Starlexxx/lazy-k8s/internal/config"
 	"github.com/Starlexxx/lazy-k8s/internal/k8s"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // getTestK8sClient creates a client for integration tests.

--- a/internal/ui/panels/daemonsets.go
+++ b/internal/ui/panels/daemonsets.go
@@ -242,7 +242,7 @@ func (p *DaemonSetsPanel) DetailView(width, height int) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(p.styles.Muted.Render("[r]estart [d]escribe [y]aml [D]elete"))
+	b.WriteString(p.styles.Muted.Render("[r]estart [l]ogs [d]escribe [y]aml [D]elete"))
 
 	return b.String()
 }

--- a/internal/ui/panels/deployments.go
+++ b/internal/ui/panels/deployments.go
@@ -293,7 +293,7 @@ func (p *DeploymentsPanel) DetailView(width, height int) string {
 	b.WriteString("\n")
 	b.WriteString(
 		p.styles.Muted.Render(
-			"[s]cale [r]estart [R]ollback [V]ersion diff [d]escribe [y]aml [D]elete",
+			"[s]cale [r]estart [R]ollback [V]ersion diff [l]ogs [d]escribe [y]aml [D]elete",
 		),
 	)
 

--- a/internal/ui/panels/statefulsets.go
+++ b/internal/ui/panels/statefulsets.go
@@ -265,7 +265,7 @@ func (p *StatefulSetsPanel) DetailView(width, height int) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(p.styles.Muted.Render("[s]cale [r]estart [d]escribe [y]aml [D]elete"))
+	b.WriteString(p.styles.Muted.Render("[s]cale [r]estart [l]ogs [d]escribe [y]aml [D]elete"))
 
 	return b.String()
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -14,6 +14,8 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 
 	"github.com/Starlexxx/lazy-k8s/internal/config"
 	"github.com/Starlexxx/lazy-k8s/internal/k8s"
@@ -1297,22 +1299,59 @@ func (m *Model) showLogs() (*Model, tea.Cmd) {
 
 	activePanel := m.panels[m.activePanelIdx]
 
-	podPanel, ok := activePanel.(*panels.PodsPanel)
+	// Single-pod logs keep the original code path; workload panels fan out
+	// across every pod matched by the workload's pod selector.
+	if podPanel, ok := activePanel.(*panels.PodsPanel); ok {
+		pod := podPanel.SelectedPod()
+		if pod == nil {
+			return m, nil
+		}
+
+		m.viewMode = ViewLogs
+		cmd := m.logView.Start(m.k8sClient, pod.Namespace, pod.Name, "")
+
+		return m, cmd
+	}
+
+	kind, name, namespace, selector, ok := workloadLogTarget(activePanel.SelectedItem())
 	if !ok {
-		m.statusBar.SetMessage("Logs only available for pods")
+		m.statusBar.SetMessage("Logs not available for this resource")
 
 		return m, nil
 	}
 
-	pod := podPanel.SelectedPod()
-	if pod == nil {
+	if selector == "" {
+		m.statusBar.SetError(fmt.Sprintf("%s %s has no pod selector", kind, name))
+
 		return m, nil
 	}
 
 	m.viewMode = ViewLogs
-	cmd := m.logView.Start(m.k8sClient, pod.Namespace, pod.Name, "")
+	cmd := m.logView.StartMulti(m.k8sClient, namespace, kind, name, selector)
 
 	return m, cmd
+}
+
+// workloadLogTarget extracts the workload kind/name/namespace/selector for a
+// selected panel item. Returns ok=false when item is nil or isn't a workload
+// type we know how to fan out logs over.
+func workloadLogTarget(item any) (kind, name, namespace, selector string, ok bool) {
+	if item == nil {
+		return "", "", "", "", false
+	}
+
+	switch v := item.(type) {
+	case *appsv1.Deployment:
+		return "Deployment", v.Name, v.Namespace, k8s.GetDeploymentPodSelector(v), true
+	case *appsv1.StatefulSet:
+		return "StatefulSet", v.Name, v.Namespace, k8s.GetStatefulSetPodSelector(v), true
+	case *appsv1.DaemonSet:
+		return "DaemonSet", v.Name, v.Namespace, k8s.GetDaemonSetPodSelector(v), true
+	case *batchv1.Job:
+		return "Job", v.Name, v.Namespace, k8s.GetJobPodSelector(v), true
+	}
+
+	return "", "", "", "", false
 }
 
 func (m *Model) confirmDelete() (*Model, tea.Cmd) {

--- a/internal/ui/workload_log_target_test.go
+++ b/internal/ui/workload_log_target_test.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkloadLogTarget(t *testing.T) {
+	sel := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "demo"},
+	}
+
+	tests := []struct {
+		name         string
+		item         any
+		wantKind     string
+		wantName     string
+		wantNs       string
+		wantSelector string
+		wantOK       bool
+	}{
+		{
+			name: "deployment",
+			item: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+				Spec:       appsv1.DeploymentSpec{Selector: sel},
+			},
+			wantKind:     "Deployment",
+			wantName:     "web",
+			wantNs:       "prod",
+			wantSelector: "app=demo",
+			wantOK:       true,
+		},
+		{
+			name: "statefulset",
+			item: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "data"},
+				Spec:       appsv1.StatefulSetSpec{Selector: sel},
+			},
+			wantKind:     "StatefulSet",
+			wantName:     "db",
+			wantNs:       "data",
+			wantSelector: "app=demo",
+			wantOK:       true,
+		},
+		{
+			name: "daemonset",
+			item: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "kube-system"},
+				Spec:       appsv1.DaemonSetSpec{Selector: sel},
+			},
+			wantKind:     "DaemonSet",
+			wantName:     "agent",
+			wantNs:       "kube-system",
+			wantSelector: "app=demo",
+			wantOK:       true,
+		},
+		{
+			name: "job",
+			item: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "migrate", Namespace: "prod"},
+				Spec:       batchv1.JobSpec{Selector: sel},
+			},
+			wantKind:     "Job",
+			wantName:     "migrate",
+			wantNs:       "prod",
+			wantSelector: "app=demo",
+			wantOK:       true,
+		},
+		{
+			name:   "nil item",
+			item:   nil,
+			wantOK: false,
+		},
+		{
+			name:   "unsupported kind",
+			item:   &appsv1.ReplicaSet{},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, name, ns, selector, ok := workloadLogTarget(tt.item)
+
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if !ok {
+				return
+			}
+
+			if kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+
+			if ns != tt.wantNs {
+				t.Errorf("namespace = %q, want %q", ns, tt.wantNs)
+			}
+
+			if selector != tt.wantSelector {
+				t.Errorf("selector = %q, want %q", selector, tt.wantSelector)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extends the `l` key beyond pods: pressing it on a Deployment, StatefulSet, DaemonSet, or Job now multiplexes logs from every matching pod into one view, prefixed with `[pod-name]` so replicas are distinguishable.
- Adds `ListPodsBySelector` and `GetPodsLogSnapshot` in the k8s client, plus `Get{Kind}PodSelector` helpers for each workload type.
- Log modal title reflects the workload (`Logs: Deployment/my-app (3 pods)`) in multi-pod mode.

Closes #27